### PR TITLE
dot removed in README.md to prevent confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Maintainers
 Communication channels
 -----------------------
 
-* \#ua-parser on freenode <irc://chat.freenode.net#ua-parser>.
+* \#ua-parser on freenode <irc://chat.freenode.net#ua-parser>
 * [mailing list](https://groups.google.com/forum/#!forum/ua-parser)
 
 Contributing Changes to regexes.yaml


### PR DESCRIPTION
This PR removes a single "." in README.md which could cause confusion while joining the room "#ua-parser." instead of "#ua-parser".
