### PR TITLE
Android fixes

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -301,25 +301,167 @@ user_agent_parsers:
   # Kindle WebKit
   - regex: '(Kindle)/(\d+)\.(\d+)'
 
-  # weird android UAs
+  #### WEIRD ANDROID CASES ####
+
+  # Retrieved from
+  # https://en.wikipedia.org/wiki/Android_version_history#Version_history_by_API_level
+  # on March 5, 2015
+
+  # Code names not used prior to 1.5
+
+  # Cupcake = 1.5
+  - regex: '(Android) Cupcake'
+    v1_replacement: '1'
+    v2_replacement: '5'
+
+  # Donut = 1.6
   - regex: '(Android) Donut'
     v1_replacement: '1'
-    v2_replacement: '2'
+    v2_replacement: '6'
 
+  # Eclair = 2.0, 2.0.1, 2.1
   - regex: '(Android) Eclair'
     v1_replacement: '2'
-    v2_replacement: '1'
 
+  # Froyo = 2.2-2.2.3
   - regex: '(Android) Froyo'
     v1_replacement: '2'
     v2_replacement: '2'
 
+  # Gingerbread = 2.3-2.3.2, 2.3.3-2.3.7
   - regex: '(Android) Gingerbread'
     v1_replacement: '2'
     v2_replacement: '3'
 
+  # Honeycomb = 3.0, 3.1, 3.2
   - regex: '(Android) Honeycomb'
     v1_replacement: '3'
+
+  # Ice Cream Sandwich = 4.0-4.0.2, 4.0.3-4.0.4
+  - regex: '(Android) Ice Cream Sandwich'
+    v1_replacement: '4'
+    v2_replacement: '0'
+
+  # Jelly Bean = 4.1, 4.2, 4.3
+  - regex: '(Android) Jelly Bean'
+    v1_replacement: '4'
+
+  # KitKat = 4.4, 4.4W
+  - regex: '(Android) KitKat'
+    v1_replacement: '4'
+
+  # Lollipop = 5.0-5.0.2
+  - regex: '(Android) Lollipop'
+    v1_replacement: '5'
+    v2_replacement: '0'
+
+  # API level 1 = 1.0
+  - regex: '(Android) 1(?!\.|\d)'
+    v1_replacement: '1'
+    v2_replacement: '0'
+
+  # API level 2 = 1.1
+  - regex: '(Android) 2(?!\.|\d)'
+    v1_replacement: '1'
+    v2_replacement: '1'
+
+  # API level 3 = 1.5
+  - regex: '(Android) 3(?!\.|\d)'
+    v1_replacement: '1'
+    v2_replacement: '5'
+
+  # API level 4 = 1.6
+  - regex: '(Android) 4(?!\.|\d)'
+    v1_replacement: '1'
+    v2_replacement: '6'
+
+  # API level 5 = 2.0
+  - regex: '(Android) 5(?!\.|\d)'
+    v1_replacement: '2'
+    v2_replacement: '0'
+
+  # API level 6 = 2.0.1
+  - regex: '(Android) 6(?!\.|\d)'
+    v1_replacement: '2'
+    v2_replacement: '0'
+    v3_replacement: '1'
+
+  # API level 7 = 2.1
+  - regex: '(Android) 7(?!\.|\d)'
+    v1_replacement: '2'
+    v2_replacement: '1'
+
+  # API level 8 = 2.2-2.2.3
+  - regex: '(Android) 8(?!\.|\d)'
+    v1_replacement: '2'
+    v2_replacement: '2'
+
+  # API level 9 = 2.3-2.3.2
+  - regex: '(Android) 9(?!\.|\d)'
+    v1_replacement: '2'
+    v2_replacement: '3'
+
+  # API level 10 = 2.3.3-2.3.7
+  - regex: '(Android) 10(?!\.|\d)'
+    v1_replacement: '2'
+    v2_replacement: '3'
+
+  # API level 11 = 3.0
+  - regex: '(Android) 11(?!\.|\d)'
+    v1_replacement: '3'
+    v2_replacement: '0'
+
+  # API level 12 = 3.1
+  - regex: '(Android) 12(?!\.|\d)'
+    v1_replacement: '3'
+    v2_replacement: '1'
+
+  # API level 13 = 3.2
+  - regex: '(Android) 13(?!\.|\d)'
+    v1_replacement: '3'
+    v2_replacement: '2'
+
+  # API level 14 = 4.0-4.0.2
+  - regex: '(Android) 14(?!\.|\d)'
+    v1_replacement: '4'
+    v2_replacement: '0'
+
+  # API level 15 = 4.0.3-4.0.4
+  - regex: '(Android) 15(?!\.|\d)'
+    v1_replacement: '4'
+    v2_replacement: '0'
+
+  # API level 16 = 4.1
+  - regex: '(Android) 16(?!\.|\d)'
+    v1_replacement: '4'
+    v2_replacement: '1'
+
+  # API level 17 = 4.2
+  - regex: '(Android) 17(?!\.|\d)'
+    v1_replacement: '4'
+    v2_replacement: '2'
+
+  # API level 18 = 4.3
+  - regex: '(Android) 18(?!\.|\d)'
+    v1_replacement: '4'
+    v2_replacement: '3'
+
+  # API level 19 = 4.4
+  - regex: '(Android) 19(?!\.|\d)'
+    v1_replacement: '4'
+    v2_replacement: '4'
+
+  # API level 20 = 4.4W
+  - regex: '(Android) 20(?!\.|\d)'
+    v1_replacement: '4'
+    v2_replacement: '4W'
+
+  # API level 21 = 5.0-5.0.2
+  - regex: '(Android) 21(?!\.|\d)'
+    v1_replacement: '5'
+    v2_replacement: '0'
+
+  #### END WEIRD ANDROID CASES ####
 
   # desktop mode
   # http://www.anandtech.com/show/3982/windows-phone-7-review

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -910,35 +910,35 @@ test_cases:
   - user_agent_string: 'Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)'
     family: 'LG'
     major: '2013'
-    minor: 
+    minor:
     patch:
-    patch_minor: 
+    patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)'
     family: 'LG'
     major: '2012'
-    minor: 
+    minor:
     patch:
-    patch_minor: 
+    patch_minor:
 
   - user_agent_string: 'Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11'
     family: 'Sony'
     major: '2013'
-    minor: 
+    minor:
     patch:
-    patch_minor: 
+    patch_minor:
 
   - user_agent_string: 'Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL40HX751; PKG1.902EUA; 2012;);; en) Presto/2.10.250 Version/11.60'
     family: 'Sony'
     major: '2012'
-    minor: 
+    minor:
     patch:
-    patch_minor: 
+    patch_minor:
 
   - user_agent_string: 'Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL22EX320; PKG4.017EUA; 2011;);; en) Presto/2.7.61 Version/11.00'
     family: 'Sony'
     major: '2011'
-    minor: 
+    minor:
     patch:
     patch_minor:
 
@@ -948,7 +948,7 @@ test_cases:
     major: '2013'
     minor: 'UE40F7000'
     patch:
-    patch_minor: 
+    patch_minor:
 
 # mid-range model
   - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2013;T-MST12DEUC-1102.1;;) WebKit'
@@ -956,57 +956,57 @@ test_cases:
     major: '2013'
     minor: 'UE32F4500'
     patch:
-    patch_minor: 
+    patch_minor:
 
 # no way to differentiate models
   - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2012;;;) WebKit'
     family: 'Samsung'
     major: '2012'
-    minor: 
+    minor:
     patch:
-    patch_minor: 
+    patch_minor:
 
   - user_agent_string: 'HbbTV/1.1.1 (;;;;;) Maple_2011'
     family: 'Samsung'
     major: '2011'
-    minor: 
+    minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.2.1; en) Presto/2.6.33 Version/10.70'
     family: 'Philips'
     major: '2012'
-    minor: 
+    minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/4.1.3 PHILIPSTV/1.1.1; en) Presto/2.10.250 Version/11.60'
     family: 'Philips'
     major: '2013'
-    minor: 
+    minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'HbbTV/1.1.1 (;Panasonic;VIERA 2011;f.532;0071-0802 2000-0000;)'
     family: 'Panasonic'
     major: '2011'
-    minor: 
+    minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)'
     family: 'Panasonic'
     major: '2012'
-    minor: 
+    minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'HbbTV/1.2.1 (;Panasonic;VIERA 2013;3.672;4101-0003 0002-0000;)'
     family: 'Panasonic'
     major: '2013'
-    minor: 
+    minor:
     patch:
-    patch_minor: 
+    patch_minor:
 
   - user_agent_string: 'HbbTV/1.1.1 (;;;;;) firetv-firefox-plugin 1.1.20'
     family: 'FireHbbTV'
@@ -2030,3 +2030,583 @@ test_cases:
     patch: '2'
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 1.0; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 1.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 1.5; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '5'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 1.6; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '6'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.0; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.0.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '0'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '2'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '2'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.3; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '2'
+    patch: '3'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch: '3'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch: '4'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch: '5'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch: '6'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch: '7'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.0; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.2.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '2'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.2.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '2'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.2.3; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '2'
+    patch: '3'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.2.4; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '2'
+    patch: '4'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.2.5; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '2'
+    patch: '5'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.2.6; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '2'
+    patch: '6'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '0'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '0'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '0'
+    patch: '3'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '0'
+    patch: '4'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '1'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '1'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '2'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '2'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.3.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '3'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4.3; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4'
+    patch: '3'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4.4; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4'
+    patch: '4'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4W; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4W'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4W.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4W'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4W.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4W'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 5.0; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '5'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 5.0.1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '5'
+    minor: '0'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 5.0.2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '5'
+    minor: '0'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 1; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '5'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '6'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 5; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 6; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '0'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 7; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 8; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 9; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 10; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 11; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 12; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 13; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 14; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 15; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 16; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 17; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 18; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 19; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 20; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '4W'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 21; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '5'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android Cupcake; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '5'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android Donut; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '1'
+    minor: '6'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android Eclair; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android Froyo; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android Gingerbread; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '2'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android Honeycomb; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '3'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android Ice Cream Sandwich; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android Jelly Bean; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android KitKat; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '4'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android Lollipop; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Android'
+    major: '5'
+    minor: '0'
+    patch:
+    patch_minor:


### PR DESCRIPTION
I've just observed (in the wild) a couple of user agents that appear to specify the Android *API level* instead of the actual Android *OS version*, even though they're isomorphic:

```
Mozilla/5.0 (Linux; U; Android 19; en-us; sm-p607t Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30

Mozilla/5.0 (Linux; U; Android 16; en-us; samsung-sgh-i437p Build/JWR66Y) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
```
I can't seem to find any references online that indicate Android may send along the [API level](https://en.wikipedia.org/wiki/Android_version_history#Version_history_by_API_level) instead of the OS version, but it also seemed easy to just drop in some `v1_replacement` & `v2_replacement` statements for all the API levels to date. I've also gone ahead and added/corrected "funky" Android UAs for newer versions code names.

Not sure yet if all the tests will pass, so I'm submitting this PR and waiting for the Travis build. Might take a couple more commits, depending on any issues discovered.