### PR TITLE
Test device model and brand values

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -54,7 +54,10 @@ function msg(name, actual, expected) {
     fixtures.forEach(function(f) {
       test(f.user_agent_string, function() {
         var device = refImpl.parse(f.user_agent_string).device;
+        fixFixture(f, ['family', 'brand', 'model']);
         assert.strictEqual(device.family, f.family, msg('device.family', device.family, f.family));
+        assert.strictEqual(device.brand, f.brand, msg('device.brand', device.brand, f.brand));
+        assert.strictEqual(device.model, f.model, msg('device.model', device.model, f.model));
       });
     });
   });


### PR DESCRIPTION
I attempted to add some failing tests for erroneous device model/brand results but found that all tests were still passing.

It seems that the brand/model items are not covered by tests. This may have been intentional, though I can't imagine why - but please let me know if there is a design concern I have missed.