### PR TITLE
Add regex and test for Vivaldi (https://vivaldi.com/)

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -264,6 +264,9 @@ user_agent_parsers:
   - regex: '(Thunderbird)/(\d+)\.(\d+)\.(\d+(?:pre)?)'
     family_replacement: 'Thunderbird'
 
+  # Vivaldi uses "Vivaldi"
+  - regex: '(Vivaldi)/(\d+)\.(\d+)\.(\d+)'
+
   # IE TechPreview uses "Edge"
   - regex: '(Edge)/(\d+)\.(\d+)'
     family_replacement: 'IE'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -1000,6 +1000,12 @@ test_cases:
     minor: '0'
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Vivaldi/1.0.83.38 Safari/537.36'
+    family: 'Vivaldi'
+    major: '1'
+    minor: '0'
+    patch: '83'
+
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36 Edge/12.0'
     family: 'IE'
     major: '12'


### PR DESCRIPTION
The creator of Opera came out with a new browser called Vivaldi.  This patch adds support for Vivaldi (which pretends to be everything else as well).