### PR TITLE
Better detection of OS X

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -680,7 +680,8 @@ os_parsers:
   # @ref: http://en.wikipedia.org/wiki/Mac_OS_X#Versions
   # @ref: http://www.puredarwin.org/curious/versions
   ##########
-  - regex: '(Mac OS X)[\s/](\d+)[_.](\d+)(?:[_.](\d+))?'
+  - regex: '((?:Mac ?|; )OS X)[\s/](?:(\d+)[_.](\d+)(?:[_.](\d+))?|Mach-O)'
+    os_replacement: 'Mac OS X'
   # Leopard
   - regex: ' (Dar)(win)/(9).(\d+).*\((?:i386|x86_64|Power Macintosh)\)'
     os_replacement: 'Mac OS X'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2100,3 +2100,31 @@ test_cases:
     patch: '2'
     patch_minor:
 
+  - user_agent_string: 'MacAppStore/2.0 (Macintosh; OS X 10.10.2; 14C81f) AppleWebKit/0600.3.10.2'
+    family: 'Mac OS X'
+    major: '10'
+    minor: '10'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'iTunes/12.0.1 (Macintosh; OS X 10.9.2) AppleWebKit/537.74.9'
+    family: 'Mac OS X'
+    major: '10'
+    minor: '9'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; U; MacOS X 10_10_2; en-US; Valve Steam Client/1424305157; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.86 Safari/537.36'
+    family: 'Mac OS X'
+    major: '10'
+    minor: '10'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Mac OS X Mach-O; en-US; rv:2.0a) Gecko/20040614 Firefox/3.0.0'
+    family: 'Mac OS X'
+    major:
+    minor:
+    patch:
+    patch_minor:
+


### PR DESCRIPTION
Better detect OS X User-Agents
Regex + new Tests

This patch fixes User-Agents with pattern `Macintosh; OS X` from being recognized as "Others".
This patch fixes User-Agents with patterns `MacOS X` or `Mac OS X Mach-O`  from being recognized as "Mac OS"
