### PR TITLE
Detect iTunes User-Agents

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -279,7 +279,7 @@ user_agent_parsers:
   - regex: '\b(Dolphin)(?: |HDCN/|/INT\-)(\d+)\.(\d+)\.?(\d+)?'
 
   # Browser/major_version.minor_version
-  - regex: '(bingbot|Bolt|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Chrome|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin)/(\d+)\.(\d+)\.?(\d+)?'
+  - regex: '(bingbot|Bolt|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Chrome|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin)/(\d+)\.(\d+)\.?(\d+)?'
 
   # Chrome/Chromium/major_version.minor_version
   - regex: '(Chromium|Chrome)/(\d+)\.(\d+)'

--- a/test_resources/pgts_browser_list.yaml
+++ b/test_resources/pgts_browser_list.yaml
@@ -2899,15 +2899,15 @@ test_cases:
     patch:
 
   - user_agent_string: 'iTunes/4.2 (Macintosh; U; PPC Mac OS X 10.2)'
-    family: 'Other'
-    major:
-    minor:
+    family: 'iTunes'
+    major: '4'
+    minor: '2'
     patch:
 
   - user_agent_string: 'iTunes/4.7 (Macintosh; U; PPC Mac OS X 10.2)'
-    family: 'Other'
-    major:
-    minor:
+    family: 'iTunes'
+    major: '4'
+    minor: '7'
     patch:
 
   - user_agent_string: 'Jakarta Commons-HttpClient/2.0final'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -1542,4 +1542,10 @@ test_cases:
     major: '2'
     minor: '0'
     patch:
+  
+  - user_agent_string: 'iTunes/12.0.1 (Macintosh; OS X 10.9.2) AppleWebKit/537.74.9'
+    family: 'iTunes'
+    major: '12'
+    minor: '0'
+    patch: '1'
 


### PR DESCRIPTION
Detect iTunes User-Agents.
Regex + new and changed Tests

iTunes User-Agents are recognized erroneously as "AppleMail".
e.g. 'iTunes/12.0.1 (Macintosh; OS X 10.9.2) AppleWebKit/537.74.9'