### PR TITLE
Fixed MS Edge detection (Edge != IE)

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -278,9 +278,8 @@ user_agent_parsers:
   # Vivaldi uses "Vivaldi"
   - regex: '(Vivaldi)/(\d+)\.(\d+)\.(\d+)'
 
-  # IE TechPreview uses "Edge"
+  # Edge/major_version.minor_version
   - regex: '(Edge)/(\d+)\.(\d+)'
-    family_replacement: 'IE'
 
   # Chrome/Chromium/major_version.minor_version.beta_version
   - regex: '(Chromium|Chrome)/(\d+)\.(\d+)\.(\d+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -1002,10 +1002,10 @@ test_cases:
     minor: '0'
     patch: '83'
 
-  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36 Edge/12.0'
-    family: 'IE'
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.9600'
+    family: 'Edge'
     major: '12'
-    minor: '0'
+    minor: '9600'
     patch:
 
   - user_agent_string: 'Mozilla/4.0 (Vodafone/1.0/LG-GU280/v10a Browser/Obigo-Q7.3 MMS/LG-MMS-V1.0/1.2 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1)'


### PR DESCRIPTION
IE on Windows 10 no longer uses the Edge engine and is again reporting as Trident rv.11. So we can now correctly detect the Edge engine as the Edge browser.