### PR TITLE
removal of negative lookaheads

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1,6 +1,10 @@
 user_agent_parsers:
   #### SPECIAL CASES TOP ####
 
+  # @note: iOS / OSX Applications
+  - regex: '(CFNetwork)(?:/(\d+)\.(\d+)\.?(\d+)?)?'
+    family_replacement: 'CFNetwork'
+
   # Pingdom
   - regex: '(Pingdom.com_bot_version_)(\d+)\.(\d+)'
     family_replacement: 'PingdomBot'
@@ -16,7 +20,7 @@ user_agent_parsers:
   # Bots Pattern '/name-0.0'
   - regex: '/((?:Ant-)?Nutch|[A-z]+[Bb]ot|[A-z]+[Ss]pider|Axtaris|fetchurl|Isara|ShopSalad|Tailsweep)[ \-](\d+)(?:\.(\d+)(?:\.(\d+))?)?'
   # Bots Pattern 'name/0.0'
-  - regex: '(008|Altresium|Argus|BaiduMobaider|BoardReader|DNSGroup|DataparkSearch|EDI|Goodzer|Grub|INGRID|Infohelfer|LinkedInBot|LOOQ|Nutch|PathDefender|Peew|PostPost|Steeler|Twitterbot|VSE|WebCrunch|WebZIP|Y!J-BR[A-Z]|YahooSeeker|envolk|sproose|wminer)/(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:(?!CFNetwork).)*$'
+  - regex: '(008|Altresium|Argus|BaiduMobaider|BoardReader|DNSGroup|DataparkSearch|EDI|Goodzer|Grub|INGRID|Infohelfer|LinkedInBot|LOOQ|Nutch|PathDefender|Peew|PostPost|Steeler|Twitterbot|VSE|WebCrunch|WebZIP|Y!J-BR[A-Z]|YahooSeeker|envolk|sproose|wminer)/(\d+)(?:\.(\d+)(?:\.(\d+))?)?'
 
   # MSIECrawler
   - regex: '(MSIE) (\d+)\.(\d+)([a-z]\d?)?;.* MSIECrawler'
@@ -26,14 +30,14 @@ user_agent_parsers:
   - regex: '(Google-HTTP-Java-Client|Apache-HttpClient|http%20client|Python-urllib|HttpMonitor|TLSProber|WinHTTP|JNLP)(?:[ /](\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
 
   # Bots
-  - regex: '(1470\.net crawler|50\.nu|8bo Crawler Bot|Aboundex|Accoona-[A-z]+-Agent|AdsBot-Google(?:-[a-z]+)?|altavista|AppEngine-Google|archive.*?\.org_bot|archiver|Ask Jeeves|[Bb]ai[Dd]u[Ss]pider(?:-[A-Za-z]+)*|bingbot|BingPreview|blitzbot|BlogBridge|BoardReader(?: [A-Za-z]+)*|boitho.com-dc|BotSeer|\b\w*favicon\w*\b|\bYeti(?:-[a-z]+)?|Catchpoint bot|[Cc]harlotte|Checklinks|clumboot|Comodo HTTP\(S\) Crawler|Comodo-Webinspector-Crawler|ConveraCrawler|CRAWL-E|CrawlConvera|Daumoa(?:-feedfetcher)?|Feed Seeker Bot|findlinks|Flamingo_SearchEngine|FollowSite Bot|furlbot|Genieo|gigabot|GomezAgent|gonzo1|(?:[a-zA-Z]+-)?Googlebot(?:-[a-zA-Z]+)?|Google SketchUp|grub-client|gsa-crawler|heritrix|HiddenMarket|holmes|HooWWWer|htdig|ia_archiver|ICC-Crawler|Icarus6j|ichiro(?:/mobile)?|IconSurf|IlTrovatore(?:-Setaccio)?|InfuzApp|Innovazion Crawler|InternetArchive|IP2[a-z]+Bot|jbot\b|KaloogaBot|Kraken|Kurzor|larbin|LEIA|LesnikBot|Linguee Bot|LinkAider|LinkedInBot|Lite Bot|Llaut|lycos|Mail\.RU_Bot|masidani_bot|Mediapartners-Google|Microsoft .*? Bot|mogimogi|mozDex|MJ12bot|msnbot(?:-media *)?|msrbot|netresearch|Netvibes|NewsGator[^/]*|^NING|Nutch[^/]*|Nymesis|ObjectsSearch|Orbiter|OOZBOT|PagePeeker|PagesInventory|PaxleFramework|Peeplo Screenshot Bot|PlantyNet_WebRobot|Pompos|Read%20Later|Reaper|RedCarpet|Retreiver|Riddler|Riddler|Rival IQ|scooter|Scrapy|Scrubby|searchsight|seekbot|semanticdiscovery|Simpy|SimplePie|SEOstats|SimpleRSS|Slurp|snappy|Speedy Spider|Squrl Java|[Tt]eoma(?![Bb]ar)|TheUsefulbot|ThumbShotsBot|Thumbshots\.ru|TwitterBot|URL2PNG|Vagabondo|VoilaBot|^vortex|Votay bot|^voyager|WASALive.Bot|Web-sniffer|WebThumb|WeSEE:[A-z]+|WhatWeb|WIRE|WordPress|Wotbox|www\.almaden\.ibm\.com|Xenu(?:.s)? Link Sleuth|Xerka [A-z]+Bot|yacy(?:bot)?|Yahoo[a-z]*Seeker|Yahoo! Slurp|Yandex\w+|YodaoBot(?:-[A-z]+)?|YottaaMonitor|Yowedo|^Zao|^Zao-Crawler|ZeBot_www\.ze\.bz|ZooShot|ZyBorg)(?:[ /]v?(\d+)(?:\.(\d+)(?:\.(\d+))?)?)?(?:(?!CFNetwork).)*$'
+  - regex: '(1470\.net crawler|50\.nu|8bo Crawler Bot|Aboundex|Accoona-[A-z]+-Agent|AdsBot-Google(?:-[a-z]+)?|altavista|AppEngine-Google|archive.*?\.org_bot|archiver|Ask Jeeves|[Bb]ai[Dd]u[Ss]pider(?:-[A-Za-z]+)*|bingbot|BingPreview|blitzbot|BlogBridge|BoardReader(?: [A-Za-z]+)*|boitho.com-dc|BotSeer|\b\w*favicon\w*\b|\bYeti(?:-[a-z]+)?|Catchpoint bot|[Cc]harlotte|Checklinks|clumboot|Comodo HTTP\(S\) Crawler|Comodo-Webinspector-Crawler|ConveraCrawler|CRAWL-E|CrawlConvera|Daumoa(?:-feedfetcher)?|Feed Seeker Bot|findlinks|Flamingo_SearchEngine|FollowSite Bot|furlbot|Genieo|gigabot|GomezAgent|gonzo1|(?:[a-zA-Z]+-)?Googlebot(?:-[a-zA-Z]+)?|Google SketchUp|grub-client|gsa-crawler|heritrix|HiddenMarket|holmes|HooWWWer|htdig|ia_archiver|ICC-Crawler|Icarus6j|ichiro(?:/mobile)?|IconSurf|IlTrovatore(?:-Setaccio)?|InfuzApp|Innovazion Crawler|InternetArchive|IP2[a-z]+Bot|jbot\b|KaloogaBot|Kraken|Kurzor|larbin|LEIA|LesnikBot|Linguee Bot|LinkAider|LinkedInBot|Lite Bot|Llaut|lycos|Mail\.RU_Bot|masidani_bot|Mediapartners-Google|Microsoft .*? Bot|mogimogi|mozDex|MJ12bot|msnbot(?:-media *)?|msrbot|netresearch|Netvibes|NewsGator[^/]*|^NING|Nutch[^/]*|Nymesis|ObjectsSearch|Orbiter|OOZBOT|PagePeeker|PagesInventory|PaxleFramework|Peeplo Screenshot Bot|PlantyNet_WebRobot|Pompos|Read%20Later|Reaper|RedCarpet|Retreiver|Riddler|Riddler|Rival IQ|scooter|Scrapy|Scrubby|searchsight|seekbot|semanticdiscovery|Simpy|SimplePie|SEOstats|SimpleRSS|Slurp|snappy|Speedy Spider|Squrl Java|TheUsefulbot|ThumbShotsBot|Thumbshots\.ru|TwitterBot|URL2PNG|Vagabondo|VoilaBot|^vortex|Votay bot|^voyager|WASALive.Bot|Web-sniffer|WebThumb|WeSEE:[A-z]+|WhatWeb|WIRE|WordPress|Wotbox|www\.almaden\.ibm\.com|Xenu(?:.s)? Link Sleuth|Xerka [A-z]+Bot|yacy(?:bot)?|Yahoo[a-z]*Seeker|Yahoo! Slurp|Yandex\w+|YodaoBot(?:-[A-z]+)?|YottaaMonitor|Yowedo|^Zao|^Zao-Crawler|ZeBot_www\.ze\.bz|ZooShot|ZyBorg)(?:[ /]v?(\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
 
   # Bots General matcher 'name/0.0'
-  - regex: '(?:\/[A-Za-z0-9\.]+)? *([A-Za-z0-9 \-_\!\[\]:]*(?:[Aa]rchiver|[Ii]ndexer|[Ss]craper|[Bb]ot|[Ss]pider|[Cc]rawl[a-z]*))/(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:(?!CFNetwork).)*$'
+  - regex: '(?:\/[A-Za-z0-9\.]+)? *([A-Za-z0-9 \-_\!\[\]:]*(?:[Aa]rchiver|[Ii]ndexer|[Ss]craper|[Bb]ot|[Ss]pider|[Cc]rawl[a-z]*))/(\d+)(?:\.(\d+)(?:\.(\d+))?)?'
   # Bots General matcher 'name 0.0'
-  - regex: '(?:\/[A-Za-z0-9\.]+)? *([A-Za-z0-9 _\!\[\]:]*(?:[Aa]rchiver|[Ii]ndexer|[Ss]craper|[Bb]ot|[Ss]pider|[Cc]rawl[a-z]*)) (\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:(?!CFNetwork).)*$'
+  - regex: '(?:\/[A-Za-z0-9\.]+)? *([A-Za-z0-9 _\!\[\]:]*(?:[Aa]rchiver|[Ii]ndexer|[Ss]craper|[Bb]ot|[Ss]pider|[Cc]rawl[a-z]*)) (\d+)(?:\.(\d+)(?:\.(\d+))?)?'
   # Bots containing spider|scrape|bot(but not CUBOT)|Crawl
-  - regex: '((?:[A-z0-9]+|[A-z\-]+ ?)?(?: the )?(?:[Ss][Pp][Ii][Dd][Ee][Rr]|[Ss]crape|[A-z]{2}(?!C[Uu])[Bb]ot|[Cc][Rr][Aa][Ww][Ll])[A-z0-9]*)(?:(?:[ /]| v)(\d+)(?:\.(\d+)(?:\.(\d+))?)?)?(?:(?!CFNetwork).)*$'
+  - regex: '((?:[A-z0-9]+|[A-z\-]+ ?)?(?: the )?(?:[Ss][Pp][Ii][Dd][Ee][Rr]|[Ss]crape|[A-Za-z0-9-]*(?:[^C][^Uu])[Bb]ot|[Cc][Rr][Aa][Ww][Ll])[A-z0-9]*)(?:(?:[ /]| v)(\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
 
   # HbbTV standard defines what features the browser should understand.
   # but it's like targeting "HTML5 browsers", effective browser support depends on the model
@@ -367,9 +371,6 @@ user_agent_parsers:
     family_replacement: 'Bon Echo'
 
   # @note: iOS / OSX Applications
-  - regex: '(CFNetwork)(?:/(\d+)\.(\d+)\.?(\d+)?)?'
-    family_replacement: 'CFNetwork'
-
   - regex: '(iPod).+Version/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Mobile Safari'
   - regex: '(iPod).*Version/(\d+)\.(\d+)'
@@ -1178,15 +1179,15 @@ device_parsers:
   # @ref: http://www.archos.com/de/products/tablets.html
   # @ref: http://www.archos.com/de/products/smartphones/index.html
   #########
-  - regex: '; *(?:ARCHOS|Archos) ?(GAMEPAD(?:(?! Build|[;/\(\)\-]).)*)'
-    device_replacement: 'Archos $1'
-    brand_replacement: 'Archos'
-    model_replacement: '$1'
-  - regex: '(?:ARCHOS|Archos)[ _]?((?:(?! Build|[;/\(\)\-]).)+)'
+  - regex: '; *(?:ARCHOS|Archos) ?(GAMEPAD.*?)(?: Build|[;/\(\)\-])'
     device_replacement: 'Archos $1'
     brand_replacement: 'Archos'
     model_replacement: '$1'
   - regex: 'ARCHOS; GOGI; ([^;]+);'
+    device_replacement: 'Archos $1'
+    brand_replacement: 'Archos'
+    model_replacement: '$1'
+  - regex: '(?:ARCHOS|Archos)[ _]?(.*?)(?: Build|[;/\(\)\-]|$)'
     device_replacement: 'Archos $1'
     brand_replacement: 'Archos'
     model_replacement: '$1'
@@ -1273,7 +1274,7 @@ device_parsers:
   # @ref: ??
   # @note: Take care with Docomo T-01 Toshiba
   #########
-  - regex: '; *(T-(?:(?!01)\d{2})[^;/]+) Build'
+  - regex: '; *(T-(?:07|[^0]\d)[^;/]+) Build'
     device_replacement: '$1'
     brand_replacement: 'Audiosonic'
     model_replacement: '$1'
@@ -1687,7 +1688,7 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'SonyEricsson'
     model_replacement: '$1'
-  - regex: '; *(T\-01[^;/]+) Build'
+  - regex: '; *(T\-0[12][^;/]+) Build'
     device_replacement: '$1'
     brand_replacement: 'Toshiba'
     model_replacement: '$1'
@@ -1727,7 +1728,7 @@ device_parsers:
   # Explay
   # @ref: http://explay.ru/
   #########
-  - regex: '; *Explay[_ ]((?:(?![\)]| Build).)+)'
+  - regex: '; *Explay[_ ](.+?)(?:[\)]| Build)'
     device_replacement: '$1'
     brand_replacement: 'Explay'
     model_replacement: '$1'
@@ -1999,26 +2000,57 @@ device_parsers:
   # @ref: http://www.htc.com/www/products/
   # @ref: http://en.wikipedia.org/wiki/List_of_HTC_phones
   #########
+
+  - regex: '; *HTC[ _]([^;]+); Windows Phone'
+    device_replacement: 'HTC $1 $2'
+    brand_replacement: 'HTC'
+    model_replacement: '$1 $2'
+
   # Android HTC with Version Number matcher
   # ; HTC_0P3Z11/1.12.161.3 Build
   # ;HTC_A3335 V2.38.841.1 Build
-  - regex: '; *(?:HTC)(?:[ _/]((?:(?![ _/;\(\)]|Build|MIUI).)+))(?:[ _/]((?:(?![ _/;\(\)]|HTC|Build|MIUI).)+))?(?:[ _/]((?:(?![ _/;\(\)]|Build|MIUI).)+))?(?:[ _/]((?:(?![/;\)]|Build|MIUI).)+))?(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]+'
+  - regex: '; *(?:HTC[ _/])+([^ _/]+)(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: *Build|\))'
+    device_replacement: 'HTC $1'
+    brand_replacement: 'HTC'
+    model_replacement: '$1'
+  - regex: '; *(?:HTC[ _/])+([^ _/]+)(?:[ _/]([^ _/]+))?(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: *Build|\))'
+    device_replacement: 'HTC $1 $2'
+    brand_replacement: 'HTC'
+    model_replacement: '$1 $2'
+  - regex: '; *(?:HTC[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+))?)?(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: *Build|\))'
+    device_replacement: 'HTC $1 $2 $3'
+    brand_replacement: 'HTC'
+    model_replacement: '$1 $2 $3'
+  - regex: '; *(?:HTC[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+))?)?)?(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: *Build|\))'
     device_replacement: 'HTC $1 $2 $3 $4'
     brand_replacement: 'HTC'
     model_replacement: '$1 $2 $3 $4'
+
   # Android HTC without Version Number matcher
-  - regex: '; *(?:HTC[ ;])?(?:HTC(?:_blocked)*)(?:(?:[ _/]|; *)((?:(?![ _/;\(\)\\]|USCCHTC|HTC|Build|MIUI).)+))(?:[ _/]((?:(?![ _/;\(\)\\]|Build|MIUI|1\.0).)+))?(?:[ _/]((?:(?![ _/;\(\)\\]|Build|MIUI|1\.0).)+))?(?:[ _/]((?:(?![/;\)]|Build|MIUI|1\.0).)+))?'
-    regex_flag: 'i'
+  - regex: '; *(?:(?:HTC|htc)(?:_blocked)*[ _/])+([^ _/;]+)(?: *Build|[;\)]| - )'
+    device_replacement: 'HTC $1'
+    brand_replacement: 'HTC'
+    model_replacement: '$1'
+  - regex: '; *(?:(?:HTC|htc)(?:_blocked)*[ _/])+([^ _/]+)(?:[ _/]([^ _/;\)]+))?(?: *Build|[;\)]| - )'
+    device_replacement: 'HTC $1 $2'
+    brand_replacement: 'HTC'
+    model_replacement: '$1 $2'
+  - regex: '; *(?:(?:HTC|htc)(?:_blocked)*[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/;\)]+))?)?(?: *Build|[;\)]| - )'
     device_replacement: 'HTC $1 $2 $3 $4'
     brand_replacement: 'HTC'
     model_replacement: '$1 $2 $3 $4'
+  - regex: '; *(?:(?:HTC|htc)(?:_blocked)*[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ /;]+))?)?)?(?: *Build|[;\)]| - )'
+    device_replacement: 'HTC $1 $2 $3 $4'
+    brand_replacement: 'HTC'
+    model_replacement: '$1 $2 $3 $4'
+
   # HTC Streaming Player
   - regex: 'HTC Streaming Player [^\/]*/[^\/]*/ htc_([^/]+) /'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
   # general matcher for anything else
-  - regex: '(?:[;,] *|^)(?:htccn_chs-)?HTC[ _\-]?((?:(?! Build|clay|Android|-?Mozilla| Opera| Profile| UNTRUSTED|[;/\(\)]).)+)'
+  - regex: '(?:[;,] *|^)(?:htccn_chs-)?HTC[ _-]?([^;]+?)(?: *Build|clay|Android|-?Mozilla| Opera| Profile| UNTRUSTED|[;/\(\)]|$)'
     regex_flag: 'i'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
@@ -2029,7 +2061,7 @@ device_parsers:
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
-  - regex: '; *(ADR6200|ADR6400L|ADR6425LVW|Amaze|DesireS?|EndeavorU|Eris|EVO|Evo\d[A-Z]+|HD2|IncredibleS?|Inspire[A-Z0-9]*|Inspire[A-Z0-9]*|Sensation[A-Z0-9]*|Wildfire)(?:(?:[ _/\-])((?:(?![ _/;\(\)]|Build|MIUI).)+))(?:[ _/]((?:(?![ _/;\(\)]|Build|MIUI|1\.0).)+))?(?:[ _/]((?:(?![ _/;\(\)]|Build|MIUI|1\.0).)+))?(?:[ _/]((?:(?![/;\)]|Build|MIUI|1\.0).)+))?'
+  - regex: '; *(ADR6200|ADR6400L|ADR6425LVW|Amaze|DesireS?|EndeavorU|Eris|EVO|Evo\d[A-Z]+|HD2|IncredibleS?|Inspire[A-Z0-9]*|Inspire[A-Z0-9]*|Sensation[A-Z0-9]*|Wildfire)[ _-](.+?)(?:[/;\)]|Build|MIUI|1\.0)'
     regex_flag: 'i'
     device_replacement: 'HTC $1 $2 $3 $4'
     brand_replacement: 'HTC'
@@ -2446,7 +2478,7 @@ device_parsers:
     device_replacement: 'Lenovo $1 $2'
     brand_replacement: 'Lenovo'
     model_replacement: '$1 $2'
-  - regex: '; *(?:LNV-)?(?:=?[Ll]enovo[ _\-]?|LENOVO[ _])+((?:(?!Build|[;/\)]).)+)[;/]? *(?:Build|[;/\)])'
+  - regex: '; *(?:LNV-)?(?:=?[Ll]enovo[ _\-]?|LENOVO[ _])+(.+?)(?:Build|[;/\)])'
     device_replacement: 'Lenovo $1'
     brand_replacement: 'Lenovo'
     model_replacement: '$1'
@@ -2488,7 +2520,7 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'LG'
     model_replacement: '$1'
-  - regex: '; *(LG-)([A-Z]{1,2}\d{2,}(?:(?!Build| V\d+|[,;/\)\(]).)+)'
+  - regex: '; *(LG-)([A-Z]{1,2}\d{2,}[^,;/\)\(]*?)(?:Build| V\d+|[,;/\)\(]|$)'
     device_replacement: '$1$2'
     brand_replacement: 'LG'
     model_replacement: '$2'
@@ -2581,7 +2613,7 @@ device_parsers:
     device_replacement: 'Meizu $1'
     brand_replacement: 'Meizu'
     model_replacement: '$1'
-  - regex: '; *(?:meizu_|MEIZU )((?:(?!Build|[;\)/]).)+) *(?:Build|[;\)])'
+  - regex: '; *(?:meizu_|MEIZU )(.+?) *(?:Build|[;\)])'
     device_replacement: 'Meizu $1'
     brand_replacement: 'Meizu'
     model_replacement: '$1'
@@ -2631,7 +2663,7 @@ device_parsers:
   # Mobistel
   # @ref: http://www.mobistel.com/
   #########
-  - regex: '; *(Cynus)[ _](F5|T\d|(?:(?!Build|[;/\)]).)+) *(?:Build|[;/\)])'
+  - regex: '; *(Cynus)[ _](F5|T\d|.+?) *(?:Build|[;/\)])'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'Mobistel'
@@ -3017,7 +3049,8 @@ device_parsers:
   # Pomp
   # @ref: http://pompmobileshop.com/
   #########
-  - regex: '; *(POMP)[ _\-]((?:(?!Build|[;/\)]).)+) *(?:Build|[;/\)])'
+  #~ TODO
+  - regex: '; *(POMP)[ _\-](.+?) *(?:Build|[;/\)])'
     device_replacement: '$1 $2'
     brand_replacement: 'Pomp'
     model_replacement: '$2'
@@ -3153,7 +3186,7 @@ device_parsers:
     device_replacement: 'Samsung $1$2$3'
     brand_replacement: 'Samsung'
     model_replacement: '$2'
-  - regex: '(?:; *|^)((?:GT\-[BIiNPS]\d{4}|I9\d{2}0[A-Za-z\+]?\b)(?:(?! +Build| Linux| MIUI|[;/\)]).)*);?(?: +Build| Linux| MIUI|[;/\)])'
+  - regex: '(?:; *|^)((?:GT\-[BIiNPS]\d{4}|I9\d{2}0[A-Za-z\+]?\b)[^;/\)]*?)(?:Build|Linux|MIUI|[;/\)])'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
@@ -3375,12 +3408,7 @@ device_parsers:
   # Sprint (Operator Branded Devices)
   # @ref:
   #########
-  #~ - regex: '; *(Sprint)? ?(HTC_?)?(X515E|ATP515CKIT|APA7373KT|PG06100|APC715CKT|APX515CKT|PG86100|EVOV4G|APA9292KT|PC36100) Build'
-    #~ debug: '#0399'
-    #~ device_replacement: '$1 $2$3'
-    #~ brand_replacement: 'HTC'
-    #~ model_replacement: '$3'
-  - regex: '; *(Sprint )((?:(?!Build|[;/]).)+) *(?:Build|[;/])'
+  - regex: '; *(Sprint )(.+?) *(?:Build|[;/])'
     device_replacement: '$1$2'
     brand_replacement: 'Sprint'
     model_replacement: '$2'
@@ -3518,7 +3546,7 @@ device_parsers:
     device_replacement: '$1 $2 $3'
     brand_replacement: 'Tmobile'
     model_replacement: '$2 $3'
-  - regex: '\b(T-Mobile)[_ ]?((?:(?!Build).)*)Build'
+  - regex: '\b(T-Mobile)[_ ]?(.*?)Build'
     device_replacement: '$1 $2'
     brand_replacement: 'Tmobile'
     model_replacement: '$2'
@@ -3608,7 +3636,7 @@ device_parsers:
   # Versus
   # @ref: http://versusuk.com/support.html
   #########
-  - regex: '(TOUCH(?:TAB|PAD)(?:(?! Build).)+) Build/'
+  - regex: '(TOUCH(?:TAB|PAD).+?) Build/'
     regex_flag: 'i'
     device_replacement: 'Versus $1'
     brand_replacement: 'Versus'
@@ -3972,7 +4000,7 @@ device_parsers:
   #########
   # Alcatel Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:ALCATEL)[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:ALCATEL)[^;]*; *([^;,\)]+)'
     device_replacement: 'Alcatel $1'
     brand_replacement: 'Alcatel'
     model_replacement: '$1'
@@ -3980,7 +4008,8 @@ device_parsers:
   #########
   # Asus Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?(?:ASUS|Asus)[^;]*; *([^;,\)]+)'
+  #~ - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?(?:ASUS|Asus)[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?(?:ASUS|Asus)[^;]*; *([^;,\)]+)'
     device_replacement: 'Asus $1'
     brand_replacement: 'Asus'
     model_replacement: '$1'
@@ -3988,7 +4017,7 @@ device_parsers:
   #########
   # Dell Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:DELL|Dell)[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:DELL|Dell)[^;]*; *([^;,\)]+)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: '$1'
@@ -3996,7 +4025,7 @@ device_parsers:
   #########
   # HTC Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?(?:HTC|Htc|HTC_blocked[^;]*)[^;]*; *(?:HTC)?([^;,\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?(?:HTC|Htc|HTC_blocked[^;]*)[^;]*; *(?:HTC)?([^;,\)]+)'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
@@ -4004,7 +4033,7 @@ device_parsers:
   #########
   # Huawei Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:HUAWEI)[^;]*; *(?:HUAWEI )?([^;,\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:HUAWEI)[^;]*; *(?:HUAWEI )?([^;,\)]+)'
     device_replacement: 'Huawei $1'
     brand_replacement: 'Huawei'
     model_replacement: '$1'
@@ -4012,7 +4041,7 @@ device_parsers:
   #########
   # LG Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:LG|Lg)[^;]*; *(?:LG[ \-])?([^;,\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:LG|Lg)[^;]*; *(?:LG[ \-])?([^;,\)]+)'
     device_replacement: 'LG $1'
     brand_replacement: 'LG'
     model_replacement: '$1'
@@ -4020,15 +4049,15 @@ device_parsers:
   #########
   # Noka Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:NOKIA|Nokia)[^;]*; *(?:NOKIA ?|Nokia ?|LUMIA ?|[Ll]umia ?)*(\d{3,}[^;\)]*)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:NOKIA|Nokia)[^;]*; *(?:NOKIA ?|Nokia ?|LUMIA ?|[Ll]umia ?)*(\d{3,}[^;\)]*)'
     device_replacement: 'Lumia $1'
     brand_replacement: 'Nokia'
     model_replacement: 'Lumia $1'
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:NOKIA|Nokia)[^;]*; *(RM-\d{3,})'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:NOKIA|Nokia)[^;]*; *(RM-\d{3,})'
     device_replacement: 'Nokia $1'
     brand_replacement: 'Nokia'
     model_replacement: '$1'
-  - regex: '(?:Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)]|WPDesktop;) ?(?:ARM; ?Touch; ?|Touch; ?)?(?:NOKIA|Nokia)[^;]*; *(?:NOKIA ?|Nokia ?|LUMIA ?|[Ll]umia ?)*([^;\)]+)'
+  - regex: '(?:Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)]|WPDesktop;) ?(?:ARM; ?Touch; ?|Touch; ?)?(?:NOKIA|Nokia)[^;]*; *(?:NOKIA ?|Nokia ?|LUMIA ?|[Ll]umia ?)*([^;\)]+)'
     device_replacement: 'Nokia $1'
     brand_replacement: 'Nokia'
     model_replacement: '$1'
@@ -4036,7 +4065,7 @@ device_parsers:
   #########
   # Microsoft Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:Microsoft(?: Corporation)?)[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?)?(?:Microsoft(?: Corporation)?)[^;]*; *([^;,\)]+)'
     device_replacement: 'Microsoft $1'
     brand_replacement: 'Microsoft'
     model_replacement: '$1'
@@ -4044,7 +4073,7 @@ device_parsers:
   #########
   # Samsung Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?(?:SAMSUNG)[^;]*; *(?:SAMSUNG )?([^;,\.\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?(?:SAMSUNG)[^;]*; *(?:SAMSUNG )?([^;,\.\)]+)'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
@@ -4052,7 +4081,7 @@ device_parsers:
   #########
   # Toshiba Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?(?:TOSHIBA|FujitsuToshibaMobileCommun)[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?(?:TOSHIBA|FujitsuToshibaMobileCommun)[^;]*; *([^;,\)]+)'
     device_replacement: 'Toshiba $1'
     brand_replacement: 'Toshiba'
     model_replacement: '$1'
@@ -4060,8 +4089,7 @@ device_parsers:
   #########
   # Generic Windows Phones
   #########
-  ## - regex: '\(compatible; MSIE [^;]+; Windows Phone [^;]+; Trident/[^;]+; ?(?:ARM; Touch; ?)?IEMobile/[^;]+; ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?([^;]+); *([^;,\)]+)'
-  - regex: 'Windows Phone [^;]+; (?:(?!IEMobile/).)*IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?([^;]+); *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?)?([^;]+); *([^;,\)]+)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
@@ -4098,10 +4126,10 @@ device_parsers:
     device_replacement: 'Nokia $1'
     brand_replacement: 'Nokia'
     model_replacement: '$1$2'
-  - regex: '(?:NOKIA|Nokia)(?:\-| *)(?:([A-Za-z0-9]+)\-[0-9a-f]{32}|((?:(?!UCBrowser)[A-Za-z0-9\-])+))'
-    device_replacement: 'Nokia $1$2'
+  - regex: '(?:NOKIA|Nokia)(?:\-| *)(?:([A-Za-z0-9]+)\-[0-9a-f]{32}|([A-Za-z0-9\-]+)(?:UCBrowser)|([A-Za-z0-9\-]+))'
+    device_replacement: 'Nokia $1$2$3'
     brand_replacement: 'Nokia'
-    model_replacement: '$1$2'
+    model_replacement: '$1$2$3'
   - regex: 'Lumia ([A-Za-z0-9\-]+)'
     device_replacement: 'Lumia $1'
     brand_replacement: 'Nokia'
@@ -4299,8 +4327,7 @@ device_parsers:
   ##########
   # htc
   ##########
-  - regex: '\bHTC[ _\-]?((?:(?!-?Mozilla|fingerPrint|[;/\(\)]).)+)'
-  #- regex: 'HTC(?:[ _\-]|; *)?(?:HTC *)?((?:(?!Mozilla|BMUNTRUSTED|Opera|PROFILE)[A-Za-z0-9 _\+])+)'
+  - regex: '\b(?:HTC/|HTC/[a-z0-9]+/)?HTC[ _\-;]? *(.*?)(?:-?Mozilla|fingerPrint|[;/\(\)]|$)'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
@@ -4580,23 +4607,23 @@ device_parsers:
   - regex: 'Android[\- ][\d]+\.[\d]+; [A-Za-z]{2}\-[A-Za-z]{0,2}; WOWMobile (.+) Build'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
-  - regex: 'Android[\- ][\d]+\.[\d]+\-update1; [A-Za-z]{2}\-[A-Za-z]{0,2} *; *((?:(?!Build).)+) Build'
+  - regex: 'Android[\- ][\d]+\.[\d]+\-update1; [A-Za-z]{2}\-[A-Za-z]{0,2} *; *(.+?) Build'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
-  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *[A-Za-z]{2}[_\-][A-Za-z]{0,2}\-? *; *((?:(?!Build).)+) Build'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *[A-Za-z]{2}[_\-][A-Za-z]{0,2}\-? *; *(.+?) Build'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
-  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *[A-Za-z]{0,2}\- *; *((?:(?!Build).)+) Build'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *[A-Za-z]{0,2}\- *; *(.+?) Build'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
   # No build info at all - "Build" follows locale immediately
   - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *[a-z]{0,2}[_\-]?[A-Za-z]{0,2};? Build'
     brand_replacement: 'Generic'
     model_replacement: 'Smartphone'
-  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *\-?[A-Za-z]{2}; *((?:(?!Build).)+) Build'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *\-?[A-Za-z]{2}; *(.+?) Build'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
-  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}(?:;.*)?; *((?:(?! Build).)+) Build'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}(?:;.*)?; *(.+?) Build'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
 

--- a/test_resources/pgts_browser_list.yaml
+++ b/test_resources/pgts_browser_list.yaml
@@ -451,7 +451,7 @@ test_cases:
     patch:
 
   - user_agent_string: '$BotName/$BotVersion [en] (UNIX; U)'
-    family: 'Other'
+    family: 'BotName/$BotVersion'
     major:
     minor:
     patch:
@@ -1303,7 +1303,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'EasyDL/3.04  http://keywen.com/Encyclopedia/Bot'
-    family: 'Other'
+    family: 'Encyclopedia/Bot'
     major:
     minor:
     patch:
@@ -2968,7 +2968,7 @@ test_cases:
     family: 'Java'
     major: '1'
     minor: '8'
-    patch: null
+    patch:
 
   - user_agent_string: 'Java1.3.1_03'
     family: 'Java'
@@ -3010,7 +3010,7 @@ test_cases:
     family: 'Java'
     major: '4'
     minor: '2'
-    patch: null
+    patch:
 
   - user_agent_string: 'Java/1.4.2_01'
     family: 'Java'
@@ -3046,7 +3046,7 @@ test_cases:
     family: 'Java'
     major: '5'
     minor: '0'
-    patch: null
+    patch:
 
   - user_agent_string: 'Java/1.5.0_01'
     family: 'Java'
@@ -5329,7 +5329,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'Mozdex/0.06-dev (Mozdex; http://www.mozdex.com/bot.html; spider@mozdex.com)'
-    family: 'spider'
+    family: 'com/bot'
     major:
     minor:
     patch:
@@ -48463,9 +48463,9 @@ test_cases:
     patch:
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; AskBar 3.00; .NET CLR 1.1.4322; Fluffi Bot+)'
-    family: 'IE'
-    major: '6'
-    minor: '0'
+    family: 'Fluffi Bot'
+    major:
+    minor:
     patch:
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; AskBar 3.00; SV1)'
@@ -63409,9 +63409,9 @@ test_cases:
     patch:
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows XP Professional Bot v.5.)'
-    family: 'IE'
-    major: '6'
-    minor: '0'
+    family: 'XP Professional Bot'
+    major:
+    minor:
     patch:
 
   - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 6.0; Windows 2000)'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -5517,7 +5517,7 @@ test_cases:
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.0.4; T-02D Build/V15R47B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
     family: 'T-02D'
-    brand: 'Audiosonic'
+    brand: 'Toshiba'
     model: 'T-02D'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.0.4; T-07B Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22'
@@ -13116,9 +13116,9 @@ test_cases:
     model: 'One X'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; HTC One X - 4.1.1 - API 16 - 720x1280 Build/JRO03S) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
-    family: 'HTC One X -'
+    family: 'HTC One X'
     brand: 'HTC'
-    model: 'One X -'
+    model: 'One X'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; HTC/One_XL/1.82.162.5 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
     family: 'HTC One XL'
@@ -13486,9 +13486,9 @@ test_cases:
     model: 'Accord'
 
   - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; HTC; ACD_U)'
-    family: 'HTC ACD U'
+    family: 'HTC ACD_U'
     brand: 'HTC'
-    model: 'ACD U'
+    model: 'ACD_U'
 
   - user_agent_string: 'MobilePlugin (Linux; U; Android 2.3.5; HTC htc_ace; GRJ90)'
     family: 'HTC ace'
@@ -13546,9 +13546,9 @@ test_cases:
     model: 'Amaze 4G'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; HTC Aria\" Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mob'
-    family: 'HTC Aria'
+    family: 'HTC Aria\"'
     brand: 'HTC'
-    model: 'Aria'
+    model: 'Aria\"'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.1-update1; en-au; HTC_Aria_A6380 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17'
     family: 'HTC Aria A6380'
@@ -14091,9 +14091,9 @@ test_cases:
     model: 'Endeavoru'
 
   - user_agent_string: 'Tristit Push System;htc;endeavoru;HTC;HTC One X;o2_de;unknown;JDQ39;4.2.2'
-    family: 'HTC endeavoru'
+    family: 'HTC One X'
     brand: 'HTC'
-    model: 'endeavoru'
+    model: 'One X'
 
   - user_agent_string: 'VKAndroidApp/3.3.3-266 (Android 4.3.1; SDK 18; armeabi-v7a; HTC EndeavorU; de)'
     family: 'HTC EndeavorU'
@@ -14126,9 +14126,9 @@ test_cases:
     model: 'europe'
 
   - user_agent_string: 'search.ch/2.8 Android/4.0.3; htc_europe:HTC One V; Mozilla/5.0 (Linux; U; Android-universal)'
-    family: 'HTC europe:'
+    family: 'HTC europe:HTC One V'
     brand: 'HTC'
-    model: 'europe:'
+    model: 'europe:HTC One V'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.0.3; HTC EVA_UL Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
     family: 'HTC EVA UL'
@@ -14656,9 +14656,9 @@ test_cases:
     model: 'inspire 4G'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.8; zh-cn; HTC Inspire 4G (LTE) Build/GRJ23) UC AppleWebKit/530+ (KHTML, like Gecko) Mobile Safari/530'
-    family: 'HTC Inspire 4G  (LTE'
+    family: 'HTC Inspire 4G (LTE'
     brand: 'HTC'
-    model: 'Inspire 4G  (LTE'
+    model: 'Inspire 4G (LTE'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.1.9; zh-cn; HTC Inspire 4G For AT&T Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
     family: 'HTC Inspire 4G For AT&T'
@@ -14816,9 +14816,9 @@ test_cases:
     model: 'Lumia 900'
 
   - user_agent_string: 'Tristit Push System;htc;m7;HTC;HTC One;htc_europe;unknown;JSS15J;4.3'
-    family: 'HTC m7'
+    family: 'HTC One'
     brand: 'HTC'
-    model: 'm7'
+    model: 'One'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.4.2; HTC_M8x Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/0DFCBB'
     family: 'HTC M8x'
@@ -15046,9 +15046,9 @@ test_cases:
     model: 'one'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; HTC One - 4.3 - API 18 - 1080x1920 Build/JLS36G) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
-    family: 'HTC One - 4.3 - API 18 - 1080x1920'
+    family: 'HTC One'
     brand: 'HTC'
-    model: 'One - 4.3 - API 18 - 1080x1920'
+    model: 'One'
 
   - user_agent_string: 'Evernote Android/AM_571_655.1057103 (ru_RU); Android/4.3; HTC One/18;'
     family: 'HTC One 18'
@@ -15551,9 +15551,9 @@ test_cases:
     model: 'Rhyme S510b'
 
   - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; HTC; RIO_U)'
-    family: 'HTC RIO U'
+    family: 'HTC RIO_U'
     brand: 'HTC'
-    model: 'RIO U'
+    model: 'RIO_U'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.0.4; HTC Ruby Build/Speed Rom 7.8 By EclipzeRemix) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
     family: 'HTC Ruby'
@@ -16201,9 +16201,9 @@ test_cases:
     model: 'TyTN'
 
   - user_agent_string: 'HTC_Hermes Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12) PPC; 240x320; HTC_TyTN1.0 ProfileMIDP-2.0 ConfigurationCLDC-1.1'
-    family: 'HTC TyTN1.0 ProfileMIDP-2.0 ConfigurationCLDC-1.1'
+    family: 'HTC Hermes'
     brand: 'HTC'
-    model: 'TyTN1.0 ProfileMIDP-2.0 ConfigurationCLDC-1.1'
+    model: 'Hermes'
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.5; Trident/3.1; IEMobile/7.0; HTC; Ultimate)'
     family: 'HTC Ultimate'
@@ -16286,9 +16286,9 @@ test_cases:
     model: 'vodafone de'
 
   - user_agent_string: 'Instagram 5.0.7 Android (8/2.2.2; 240dpi; 480x800; HTC/vodafone_uk; HTC Desire; bravo; bravo; en_GB)'
-    family: 'HTC vodafone uk'
+    family: 'HTC Desire'
     brand: 'HTC'
-    model: 'vodafone uk'
+    model: 'Desire'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; HTC Vogue Build/EPE54B) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17'
     family: 'HTC Vogue'
@@ -16361,9 +16361,9 @@ test_cases:
     model: 'Windows Phone'
 
   - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HTC; Windows Phone 8 / HTC Mozart)'
-    family: 'HTC Windows Phone 8'
+    family: 'HTC Windows Phone 8 / HTC Mozart'
     brand: 'HTC'
-    model: 'Windows Phone 8'
+    model: 'Windows Phone 8 / HTC Mozart'
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; Windows Phone 8S By HTC)'
     family: 'HTC Windows Phone 8S By HTC'
@@ -16866,9 +16866,9 @@ test_cases:
     model: 'Artist'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.1; zh-cn; HTC Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
-    family: 'HTC Build'
+    family: 'HTC Build MIUI'
     brand: 'HTC'
-    model: 'Build'
+    model: 'Build MIUI'
 
   - user_agent_string: 'HTC Butterfly; 4.1.1; JRO03C; de-de'
     family: 'HTC Butterfly'
@@ -16956,9 +16956,9 @@ test_cases:
     model: 'Desire-A8181'
 
   - user_agent_string: 'HTC_Desire-orange-LS_Build'
-    family: 'HTC Desire-orange-LS_Build'
+    family: 'HTC Desire-orange-LS_'
     brand: 'HTC'
-    model: 'Desire-orange-LS_Build'
+    model: 'Desire-orange-LS_'
 
   - user_agent_string: 'com.smule.magicpiano/1.3.1 (2.2,HTC Desire,de_DE)'
     family: 'HTC Desire,de_DE'
@@ -18296,9 +18296,9 @@ test_cases:
     model: 'Z710a'
 
   - user_agent_string: 'HTC (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0)'
-    family: 'HTC'
+    family: 'HTC (compatible'
     brand: 'HTC'
-    model:
+    model: '(compatible'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 1.5; en-us; A6277 Build/CUPCAKE) AppleWebKit/528.5  (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1'
     family: 'HTC A6277'
@@ -18856,9 +18856,9 @@ test_cases:
     model: 'Sensation XE G18'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.0.3; Sensation XE with Beats Audio Z715e Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
-    family: 'HTC Sensation XE with Beats'
+    family: 'HTC Sensation XE with Beats Audio Z715e'
     brand: 'HTC'
-    model: 'Sensation XE with Beats'
+    model: 'Sensation XE with Beats Audio Z715e'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.2.2; Sensation XL Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36'
     family: 'HTC Sensation XL'
@@ -18871,9 +18871,9 @@ test_cases:
     model: 'Sensation XL G21'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.0.3; Sensation XL with Beats Audio Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
-    family: 'HTC Sensation XL with Beats'
+    family: 'HTC Sensation XL with Beats Audio'
     brand: 'HTC'
-    model: 'Sensation XL with Beats'
+    model: 'Sensation XL with Beats Audio'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.0.3; Sensation Z710e Build/IML74K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31'
     family: 'HTC Sensation Z710e'
@@ -18881,9 +18881,9 @@ test_cases:
     model: 'Sensation Z710e'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; -de; SensationXE_Beats_Z715e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
-    family: 'HTC SensationXE Beats Z715e'
+    family: 'HTC SensationXE Beats_Z715e'
     brand: 'HTC'
-    model: 'SensationXE Beats Z715e'
+    model: 'SensationXE Beats_Z715e'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; SensationXE_Z715e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
     family: 'HTC SensationXE Z715e'
@@ -18891,9 +18891,9 @@ test_cases:
     model: 'SensationXE Z715e'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; ar-; SensationXL_Beats_X315e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
-    family: 'HTC SensationXL Beats X315e'
+    family: 'HTC SensationXL Beats_X315e'
     brand: 'HTC'
-    model: 'SensationXL Beats X315e'
+    model: 'SensationXL Beats_X315e'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.7; de-de; Wildfire S Build/GRI40; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
     family: 'HTC Wildfire S'
@@ -20076,9 +20076,9 @@ test_cases:
     model: 'Touch_Diamond2'
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; HTC_Touch_Diamond2_T5353; Windows Phone 6.5)'
-    family: 'HTC Touch Diamond2 T5353'
+    family: 'HTC Touch_Diamond2_T5353'
     brand: 'HTC'
-    model: 'Touch Diamond2 T5353'
+    model: 'Touch_Diamond2_T5353'
 
   - user_agent_string: 'Mozilla/10.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) HTC_Touch_HD_T8282 Mozilla/4.0'
     family: 'HTC Touch_HD_T8282'
@@ -20111,9 +20111,9 @@ test_cases:
     model: 'Touch2'
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; HTC_Touch2_T3333; Windows Phone 6.5)'
-    family: 'HTC Touch2 T3333'
+    family: 'HTC Touch2_T3333'
     brand: 'HTC'
-    model: 'Touch2 T3333'
+    model: 'Touch2_T3333'
 
   - user_agent_string: 'Vodafone/1.0/HTC_Trinity/1.07.163.5/Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; MIDP-2.0 Configuration/CLDC-1.1; PPC; 240x32'
     family: 'HTC Trinity'
@@ -27191,9 +27191,9 @@ test_cases:
     model: 'S960'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.1; en-us; Lenovo Build/LeOS-110802-R0018) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13'
-    family: 'Lenovo'
+    family: 'Lenovo Build'
     brand: 'Lenovo'
-    model:
+    model: 'Build'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.0.3; SmartTabII10 Build/IML74K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19'
     family: 'Lenovo SmartTab II 10'
@@ -53711,9 +53711,9 @@ test_cases:
     model: 'GT-I9000B'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; GT-I9000Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
-    family: 'Samsung GT-I9000Build'
+    family: 'Samsung GT-I9000'
     brand: 'Samsung'
-    model: 'GT-I9000Build'
+    model: 'GT-I9000'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.1-update1; en-ca; GT-I9000M Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17'
     family: 'Samsung GT-I9000M'
@@ -54306,9 +54306,9 @@ test_cases:
     model: 'GT-P1000 Tablet'
 
   - user_agent_string: 'Mozilla/5.0(Linux;U;Android2.2;de-de;GT-P1000Build/FROYO)AppleWebKit/533.1(KHTML,likeGecko)Version/4.0MobileSafari/533.1'
-    family: 'Samsung GT-P1000Build'
+    family: 'Samsung GT-P1000'
     brand: 'Samsung'
-    model: 'GT-P1000Build'
+    model: 'GT-P1000'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; GT-P1000L Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
     family: 'Samsung GT-P1000L'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -4474,7 +4474,7 @@ test_cases:
     patch:
 
   - user_agent_string: '123metaspider-Bot (Version: 1.04, powered by www.123metaspider.com)'
-    family: '123metaspider'
+    family: '123metaspider-Bot'
     major:
     minor:
     patch:
@@ -5416,7 +5416,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'ShowyouBot (http://showyou.com/crawler)'
-    family: 'ShowyouBot'
+    family: 'crawler'
     major:
     minor:
     patch:
@@ -5632,7 +5632,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'EmeraldShield.com WebBot'
-    family: 'WebBot'
+    family: 'com WebBot'
     major:
     minor:
     patch:
@@ -5656,7 +5656,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'CyberPatrol SiteCat Webbot (http://www.cyberpatrol.com/cyberpatrolcrawler.asp)'
-    family: 'Webbot'
+    family: 'SiteCat Webbot'
     major:
     minor:
     patch:
@@ -6104,18 +6104,6 @@ test_cases:
     major: '4'
     minor: '2'
     patch: '1'
-
-  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9) AppleWebKit/537.71 (KHTML, like Gecko) Version/7.0 Safari/537.71 (Rival IQ, rivaliq.com)'
-    family: 'Rival IQ'
-    major:
-    minor:
-    patch:
-
-  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9) AppleWebKit/537.71 (KHTML, like Gecko) Version/7.0 Safari/537.71 (Rival IQ, rivaliq.com)'
-    family: 'Rival IQ'
-    major:
-    minor:
-    patch:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9) AppleWebKit/537.71 (KHTML, like Gecko) Version/7.0 Safari/537.71 (Rival IQ, rivaliq.com)'
     family: 'Rival IQ'


### PR DESCRIPTION
This PR removes all negative lookaheads in regexes.yaml as stated as a problem for the go-implementation in issue #63.
Unfortunately this has some side effects which required some adaptation on test cases.