### PR TITLE
 Fix a bug in one of the Android regexps.

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -4618,6 +4618,7 @@ device_parsers:
     model_replacement: '$1'
   # No build info at all - "Build" follows locale immediately
   - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *[a-z]{0,2}[_\-]?[A-Za-z]{0,2};? Build'
+    device_replacement: 'Generic Smartphone'
     brand_replacement: 'Generic'
     model_replacement: 'Smartphone'
   - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *\-?[A-Za-z]{2}; *(.+?) Build'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -79740,3 +79740,7 @@ test_cases:
     brand: 'Spider'
     model: 'Desktop'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.99; Build/MRA23D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.106 Mobile Safari/537.36'
+    family: 'Generic Smartphone'
+    brand: 'Generic'
+    model: 'Smartphone'


### PR DESCRIPTION
This regexp:
   'Android[\- ][\d]+(?:\.[\d]+){1,2}; *[a-z]{0,2}[_\-]?[A-Za-z]{0,2};? Build'

lacks a capturing group (parens) for the device name.  This means that
it needs to specify the device-name specifically in the yaml file,
but it wasn't before.  This fixes that.

Here is a user-agent that triggers the bug:

  Mozilla/5.0 (Linux; Android 5.1.99; Build/MRA23D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.106 Mobile Safari/537.36