### PR TITLE
increase node version in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - 0.12
+  - 4.0
 
 script:
   - "npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+sudo: false
 language: node_js
 node_js:
-  - 0.8
+  - 0.12
 
 script:
   - "npm test"


### PR DESCRIPTION
There seams to be problems with node v0.8 builds on travis with npm.
This PR 
- updates travis builds to node v0.12
- updates travis to run in container infrastructure
- adding node v4.0 beside v0.12