### PR TITLE
use node version 4.x and latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: node_js
 node_js:
   - 0.12
-  - 4.0
+  - 4
+  - node
 
 script:
   - "npm test"


### PR DESCRIPTION
On request this PR changes Travis CI to test with the node versions
- v0.12
- v4.x
- latest (at present v4.0.0)