### PR TITLE
Bump to v0.5.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uap-core",
   "description": "The regex file necessary to build language ports of Browserscope's user agent parser.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "maintainers": [
     {
       "name": "Tobie Langel",


### PR DESCRIPTION
Bumping to v0.5.0 mainly for UA additions and fixes. Related to #81.