### PR TITLE
iOS 9 Apps using CFNetwork

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -789,6 +789,9 @@ os_parsers:
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '10'
+  - regex: '(CF)(Network)/758\.(\d)'
+    os_replacement: 'iOS'
+    os_v1_replacement: '9'
 
   ##########
   # CFNetwork iOS Apps
@@ -812,6 +815,10 @@ os_parsers:
   - regex: 'CFNetwork/7.* Darwin/(14)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '8'
+    os_v2_replacement: '0'
+  - regex: 'CFNetwork/7.* Darwin/(15)\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '9'
     os_v2_replacement: '0'
   # iOS Apps
   - regex: '\b(iOS[ /]|iPhone(?:/| v|[ _]OS[/,]|; | OS : |\d,\d/|\d,\d; )|iPad/)(\d{1,2})[_\.](\d{1,2})(?:[_\.](\d+))?'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2180,3 +2180,10 @@ test_cases:
     minor:
     patch:
     patch_minor:
+
+  - user_agent_string: 'TestApp/1.0 CFNetwork/758.0.2 Darwin/15.0.0'
+    family: 'iOS'
+    major: '9'
+    minor: '0'
+    patch:
+    patch_minor:


### PR DESCRIPTION
This PR adds support for iOS 9.0 Apps using CFNetwork User-Agents. Related issue is #88.