### PR TITLE
More accurate detection of opera mini

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -106,6 +106,7 @@ user_agent_parsers:
   # Opera will stop at 9.80 and hide the real version in the Version string.
   # see: http://dev.opera.com/articles/view/opera-ua-string-changes/
   - regex: '(Opera Tablet).*Version/(\d+)\.(\d+)(?:\.(\d+))?'
+  - regex: '(Opera Mini)(?:/att)?/(\d+)(?:\.(\d+))?(?:\.(\d+))?'
   - regex: '(Opera)/.+Opera Mobi.+Version/(\d+)\.(\d+)'
     family_replacement: 'Opera Mobile'
   - regex: '(Opera)/(\d+)\.(\d+).+Opera Mobi'
@@ -114,7 +115,6 @@ user_agent_parsers:
     family_replacement: 'Opera Mobile'
   - regex: 'Opera Mobi'
     family_replacement: 'Opera Mobile'
-  - regex: '(Opera Mini)(?:/att)?/(\d+)\.(\d+)'
   - regex: '(Opera)/9.80.*Version/(\d+)\.(\d+)(?:\.(\d+))?'
 
   # Opera 14 for Android uses a WebKit render engine.

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -106,7 +106,7 @@ user_agent_parsers:
   # Opera will stop at 9.80 and hide the real version in the Version string.
   # see: http://dev.opera.com/articles/view/opera-ua-string-changes/
   - regex: '(Opera Tablet).*Version/(\d+)\.(\d+)(?:\.(\d+))?'
-  - regex: '(Opera Mini)(?:/att)?/(\d+)(?:\.(\d+))?(?:\.(\d+))?'
+  - regex: '(Opera Mini)(?:/att)?/(\d+)?(?:\.(\d+))?(?:\.(\d+))?'
   - regex: '(Opera)/.+Opera Mobi.+Version/(\d+)\.(\d+)'
     family_replacement: 'Opera Mobile'
   - regex: '(Opera)/(\d+)\.(\d+).+Opera Mobi'

--- a/test_resources/opera_mini_user_agent_strings.yaml
+++ b/test_resources/opera_mini_user_agent_strings.yaml
@@ -1,0 +1,1211 @@
+# Additional tests for opera mini detection.
+# List of user agent strings and corresponding versions is taken from http://www.useragentstring.com/pages/Opera%20Mini/
+
+test_cases:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.334; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.6.35766/35.5706; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '6'
+    patch: '35766'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.5.33361/31.1350; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '5'
+    patch: '33361'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.29530/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '29530'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32694'
+
+  - user_agent_string: 'Opera/9.80 (iPad; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32694'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/7.1.32444/35.5706; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32444'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/7.1.32444/35.2883; U; ru) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32444'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/7.1.32052/35.5706; U; id) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '1'
+    patch: '32052'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/7.0.4/28.2555; U; fr) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '0'
+    patch: '4'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.0.29952/28.2075; U; es) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '0'
+    patch: '29952'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.5.29702/28.2647; U; es) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '5'
+    patch: '29702'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.5.26955/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '5'
+    patch: '26955'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.24288/25.729; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24288'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (BlackBerry; Opera Mini/6.24209/27.1366; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24209'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.24096/25.657; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24096'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.24093/26.1305; U; en) Presto/2.8.119 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24093'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.24093/25.657; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '24093'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.1.25759/25.872; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '1'
+    patch: '25759'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/6.1.25378/25.677; U; th) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '1'
+    patch: '25378'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/6.1.25375/25.657; U; es) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '1'
+    patch: '25375'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.0.24455/28.2766; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '0'
+    patch: '24455'
+
+  - user_agent_string: 'Opera/9.80 (Android;Opera Mini/6.0.24212/24.746 U;en) Presto/2.5.25 Version/10.5454'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '0'
+    patch: '24212'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.0.24095/24.760; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '0'
+    patch: '24095'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.0.24095/24.741; U; zh) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '6'
+    minor: '0'
+    patch: '24095'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22784/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22784'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22784/22.394; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22784'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22784/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22784'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22783/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22783'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22783/22.478; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22783'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22783/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22783'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/5.1.22460/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22460'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/5.1.22460/22.478; U; fr) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22460'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/5.1.22460/22.414; U; de) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22460'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/5.1.22396/22.478; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22396'
+
+  - user_agent_string: 'Opera/9.80 (BlackBerry; Opera Mini/5.1.22303/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22303'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296; BlackBerry9800; U; AppleWebKit/23.370; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/22.87; U; fr) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/22.87; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/22.478; U; fr) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/22.387; U; fr) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '22296'
+
+  - user_agent_string: 'Opera/9.50 (J2ME/MIDP; Opera Mini/5.1.21965/20.2513; U; en)'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21965'
+
+  - user_agent_string: 'Opera/9.80 (Windows Mobile; Opera Mini/5.1.21595/25.657; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21595'
+
+  - user_agent_string: 'Opera/9.80 (Windows Mobile; Opera Mini/5.1.21594/22.387; U; ru) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21594'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21415/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21415'
+
+  - user_agent_string: 'Opera/10.61 (J2ME/MIDP; Opera Mini/5.1.21219/19.999; en-US; rv:1.9.3a5) WebKit/534.5 Presto/2.6.30'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21219'
+
+  - user_agent_string: 'Opera/9.80(J2ME/MIDP; Opera Mini/5.1.21214/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21214/22.414; U; ro) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21214/22.387; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21214'
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/5.1.21126/19.892; U; de) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21126'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21051/27.1573; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21051'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21051/23.377; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21051'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21051/20.2477; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch: '21051'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.3521/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '3521'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.3521/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '3521'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.3521/18.684; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '3521'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.22349/37.6584; U; en) Presto/2.12.423 Version/12.16'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '22349'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.20873/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '20873'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.19693Mod.by.Handler/23.390; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '19693'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.19693Mod.by.Handler/18.794; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '19693'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.19693/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '19693'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.19683/1278; U; ko) Presto/2.2.0'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '19683'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741Mod.by.Handler/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/886; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/870; U; fr) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18741/18.794; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18741'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18635Mod.by.Handler/23.377; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18635'
+
+  - user_agent_string: 'Opera/9.80 (Windows NT 5.1; U; Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18635/1030; U; en) Presto/2.4.15; ru) Presto/2.8.99 Version/11.10'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18635'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.18635/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '18635'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.17443/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '17443'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.17443/20.2477; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '17443'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.17381/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '17381'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.16823Mod.by.Handler/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '16823'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.16823/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '16823'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.15650/20.2479; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '15650'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/iPhone;Opera Mini/5.0.019802/886; U; ja)Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/iPhone;Opera Mini/5.0.019802/886; U; ja)Presto/ 2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/iPhone;Opera Mini/5.0.019802/886; U; ja) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.019802/886; U; ja) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.019802/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.019802/22.414; U; de) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.019802/18.738; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '019802'
+
+  - user_agent_string: 'Opera/9.80 (iPhone; Opera Mini/5.0.0176/764; U; en) Presto/2.4.154.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '0176'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.0.862 Profile/24.743; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.0.423 Profile/18.684; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0.0.351 Profile/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0(Windows; U; Windows NT 5.1; en-US)/23.390; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 6.1; sv-SE) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/24.838; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.2.3) Gecko/23.377; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows NT 6.1; WOW64) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (SymbianOS/24.838; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Linux; U; Android 2.2; fr-lu; HTC Legend Build/24.838; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Linux; U; Android 2.2; en-sa; HTC_DesireHD_A9191 Build/24.741; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; xxxx like Mac OS X; en) AppleWebKit/24.838; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/23.405; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/23.377; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (BlackBerry; U; BlackBerry9800; en-GB) AppleWebKit/24.783; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (BlackBerry; U; BlackBerry 9800) AppleWebKit/24.783; U; es) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.5.33867/35.2883; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '5'
+    patch: '33867'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.4.Vista/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '4'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.4.29476/27.1573; U; id) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '4'
+    patch: '29476'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.4.26736/28.2647; U; it) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '4'
+    patch: '26736'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.4.0.60 (Windows XP)/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '4'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.24214; iPhone; CPU iPhone OS 4_2_1 like Mac OS X; AppleWebKit/24.783; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '3'
+    patch: '24214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.24214/27.1407; U; id) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '3'
+    patch: '24214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.24214 (Windows; U; Windows NT 6.1) AppleWebKit/24.838; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '3'
+    patch: '24214'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.13337/25.657; U; ro) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '3'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.24721/30.3316; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '24721'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.23453/28.2647; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '23453'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.21465/22.478; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '21465'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.21465/22.387; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '21465'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.19634/23.333; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '19634'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.18887/22.478; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '18887'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.16320/29.3594; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '16320'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.16007Mod.by.Handler/23.390; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '16007'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410QUAIN/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/23.333; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/22.401; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/20.2485; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/18.678; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.60 (J2ME/MIDP;Opera Mini/4.2.15410Mod.by.Handler/503; U; en)Presto/2.2.0'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.50 (J2ME/MIDP; Opera Mini/4.2.15410Mod.by.Handler/20.2590; U; en)'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410/24.899; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15410/22.394; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15410'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.15066/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '15066'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912mod.By.onome/22.401; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912Mod.by.Handler/24.783; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912Mod.by.Handler/23.377; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912Mod.By.www.9jamusic.cz.cc/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/870; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/35.5706; U; id) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/24.746; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/23.333; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/22.394; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14912'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14885/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14885'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14881Mod.by.Handler/24.743; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14881'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14881Mod.by.Handler/23.317; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14881'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14753/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14753'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14409/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14409'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14320/886; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14320'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14320/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14320'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14320/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '14320'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13943/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13943'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13918/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13918'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13400/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13400'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13337.Mod.by.Handler/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13337/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13337/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13337/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13337'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13265/870; U; ro) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13265'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13221/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13221'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13221/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13221'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13057/870; U; ja) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch: '13057'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.2 19.42.55/19.892; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.18061/27.1407; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '18061'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.15082/870; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '15082'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.15082/25.677; U; vi) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '15082'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.15082/20.2489; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '15082'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.14287/22.387; U; id) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '14287'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13907/21.529; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '13907'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13573/20.2485; U; zh) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '13573'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.12965/19.892; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '12965'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.11321/24.871; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '1'
+    patch: '11321'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0.8462/22.414; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch: '8462'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0.8462/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch: '8462'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0.10247/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch: '10247'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0.10031/22.453; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch: '10031'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/870; U; id) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/22.453; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/22.401; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0/22.394; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (X11; U; Linux i686 (x86_64); en-US; rv:1.8.1.11) Gecko/23.390; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (Linux; U;'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (compatible; MSIE 5.0; UNIX) Opera 6.12 [en]/24.838; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/24.705; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.60 (J2ME/MIDP; Opera Mini/4.0/490; U; en) Presto/2.2.0'
+    family: 'Opera Mini'
+    major: '4'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/3.1.10423/22.387; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '3'
+    minor: '1'
+    patch: '10423'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/1.6.0_13/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '1'
+    minor: '6'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/1.6.0_13/19.916; U; en) Presto/2.5.25'
+    family: 'Opera Mini'
+    major: '1'
+    minor: '6'
+    patch: '0'
+
+  - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/1.0.30710/29.3594; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '1'
+    minor: '0'
+    patch: '30710'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/1.0/886; U; en) Presto/2.4.15'
+    family: 'Opera Mini'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/SymbianOS/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/Nokia2730c-1/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/Mozilla/23.334; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/(Windows; U; Windows NT 5.1; en-US) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major:
+    minor:
+    patch:
+

--- a/tests/test.js
+++ b/tests/test.js
@@ -14,7 +14,8 @@ function msg(name, actual, expected) {
   return "Expected " + name + " to be " + JSON.stringify(expected) + " got " + JSON.stringify(actual) + " instead.";
 }
 
-['../test_resources/firefox_user_agent_strings.yaml', '../tests/test_ua.yaml', '../test_resources/pgts_browser_list.yaml'].forEach(function(fileName) {
+['../test_resources/firefox_user_agent_strings.yaml', '../tests/test_ua.yaml', '../test_resources/pgts_browser_list.yaml',
+  '../test_resources/opera_mini_user_agent_strings.yaml'].forEach(function(fileName) {
   var fixtures = readYAML(fileName).test_cases;
   suite(fileName, function() {
     fixtures.forEach(function(f) {

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -634,7 +634,7 @@ test_cases:
     family: 'Opera Mini'
     major: '5'
     minor: '1'
-    patch:
+    patch: '191'
 
   - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.24455/25.677; U; fr) Presto/2.5.25 Version/10.54'
     family: 'Opera Mini'
@@ -646,7 +646,31 @@ test_cases:
     family: 'Opera Mini'
     major: '7'
     minor: '0'
+    patch: '31437'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
     patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/22.478; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor: '80'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Opera Mini'
+    major: '9'
+    minor:
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (Android; Opera Mini/7.6.35766/35.5706; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Opera Mini'
+    major: '7'
+    minor: '6'
+    patch: '35766'
 
   - user_agent_string: 'Opera/9.80 (S60; SymbOS; Opera Mobi/275; U; es-ES) Presto/2.4.13 Version/10.00'
     family: 'Opera Mobile'
@@ -1142,14 +1166,14 @@ test_cases:
     family: 'Opera Mini'
     major: '4'
     minor: '2'
-    patch:
+    patch: '14812'
     patch_minor:
 
   - user_agent_string: 'SAMSUNG-SGH-A897/A897UCJC1; Mozilla/5.0 (Profile/MIDP-2.0 Configuration/CLDC-1.1; Opera Mini/att/4.2.15304; U; fr-US) Opera 9.50'
     family: 'Opera Mini'
     major: '4'
     minor: '2'
-    patch:
+    patch: '15304'
     patch_minor:
 
   - user_agent_string: 'MQQBrowser/39 Mozilla/5.0 (iPhone 4S; CPU iPhone OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10A523 Safari/7534.48.3'


### PR DESCRIPTION
Hello!

In this pull request I've added tests for opera mini user agent strings from http://www.useragentstring.com/pages/Opera%20Mini/

In order to make the new tests pass I made following changes:
 - moved opera mini regex upper, so it catches `Opera Mini...Opera Mobi` cases
 - made all the versions of opera mini optional: there are cases when we have no versions
 - added patch version to opera mini (this caused fixes in existing tests)