### PR TITLE
Add Samsung Internet

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -205,6 +205,10 @@ user_agent_parsers:
   - regex: 'Windows Phone .*(Edge)/(\d+)\.(\d+)'
     family_replacement: 'Edge Mobile'
 
+  # Samsung Internet (based on Chrome, but lacking some features)
+  - regex: '(SamsungBrowser)/(\d+)\.(\d+)'
+    family_replacement: 'Samsung Internet'
+
   # Chrome Mobile
   - regex: '(CrMo)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -3735,6 +3735,30 @@ test_cases:
     minor: '7'
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG GT-I9506-ORANGE Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
+    family: 'Samsung Internet'
+    major: '2'
+    minor: '1'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-T800 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.0 Chrome/38.0.2125.102 Safari/537.36'
+    family: 'Samsung Internet'
+    major: '3'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G920F Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.2 Chrome/38.0.2125.102 Mobile Safari/537.36'
+    family: 'Samsung Internet'
+    major: '3'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-T710 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Safari/537.36'
+    family: 'Samsung Internet'
+    major: '3'
+    minor: '5'
+    patch:
+
   - user_agent_string: 'ScSpider/0.2'
     family: 'ScSpider'
     major: '0'


### PR DESCRIPTION
The built-in browser in Samsung Android devices is based on Chrome, but lacks some features, such as  the Intl API.
So Chrome version advertised in the UA string does not reflect reality.

I added detection before Chrome Mobile so it could be handled differently in
https://github.com/Financial-Times/polyfill-service/issues/509

http://developer.samsung.com/technical-doc/view.do?v=T000000202
http://developer.samsung.com/technical-doc/view.do?v=T000000203L