### PR TITLE
Update test_os.yaml

### DIFF
--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2128,7 +2128,7 @@ test_cases:
     family: 'Firefox OS'
     major: '1'
     minor: '0'
-    patch: '1'
+    patch: 
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/18.1 Firefox/26.0'


### PR DESCRIPTION
testParseOS(ua_parser.CachingParserTest)  Time elapsed: 0.047 sec  <<< FAILURE!
java.lang.AssertionError: Mozilla/5.0 (Mobile; rv:26.0) Gecko/18.0 Firefox/26.0
Expected: is <{"family": "Firefox OS", "major": "1", "minor": "0", "patch": "1", "patch_minor": ""}>
     got: <{"family": "Firefox OS", "major": "1", "minor": "0", "patch": "", "patch_minor": ""}>

```
at org.junit.Assert.assertThat(Assert.java:780)
at ua_parser.ParserTest.testOSFromYaml(ParserTest.java:140)
```

Cannot get the patch version from current yaml
