### PR TITLE
Add Support for WKWebView

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -396,15 +396,15 @@ user_agent_parsers:
   - regex: '(iPod|iPhone|iPad).+Version/(\d+)\.(\d+)(?:\.(\d+))?.* Safari'
     family_replacement: 'Mobile Safari'
   - regex: '(iPod|iPhone|iPad).+Version/(\d+)\.(\d+)(?:\.(\d+))?'
-    family_replacement: 'Mobile Safari UIWebView'
+    family_replacement: 'Mobile Safari UI/WKWebView'
   - regex: '(iPod|iPhone|iPad);.*CPU.*OS (\d+)_(\d+)(?:_(\d+))?.*Mobile.* Safari'
     family_replacement: 'Mobile Safari'
   - regex: '(iPod|iPhone|iPad);.*CPU.*OS (\d+)_(\d+)(?:_(\d+))?.*Mobile'
-    family_replacement: 'Mobile Safari UIWebView'
+    family_replacement: 'Mobile Safari UI/WKWebView'
   - regex: '(iPod|iPhone|iPad).* Safari'
     family_replacement: 'Mobile Safari'
   - regex: '(iPod|iPhone|iPad)'
-    family_replacement: 'Mobile Safari UIWebView'
+    family_replacement: 'Mobile Safari UI/WKWebView'
 
   - regex: '(AvantGo) (\d+).(\d+)'
 

--- a/test_resources/pgts_browser_list.yaml
+++ b/test_resources/pgts_browser_list.yaml
@@ -55,7 +55,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'Alizee iPod 2005 (Beta; Mac OS X)'
-    family: 'Mobile Safari UIWebView'
+    family: 'Mobile Safari UI/WKWebView'
     major:
     minor:
     patch:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -463,7 +463,7 @@ test_cases:
     patch: '2'
 
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Mobile/11D257'
-    family: 'Mobile Safari UIWebView'
+    family: 'Mobile Safari UI/WKWebView'
     major: '7'
     minor: '1'
     patch: '2'
@@ -6394,7 +6394,7 @@ test_cases:
     patch: '1'
 
   - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile'
-    family: 'Mobile Safari UIWebView'
+    family: 'Mobile Safari UI/WKWebView'
     major: '4'
     minor: '3'
     patch: '2'


### PR DESCRIPTION
### Background

iOS actually has two types of webviews:

- `UIWebView`
- `WKWebView`

...but they both return the same user agent.

### The Change

PR #101 added `UIWebView`.  This renames it to `UI/WKWebView` to represent both possibilities.