### PR TITLE
AppleMail -> Apple Mail

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -506,7 +506,7 @@ user_agent_parsers:
 
   # apple mail - not directly detectable, have it after Safari stuff
   - regex: '(AppleWebKit)/(\d+)\.(\d+)\.(\d+)'
-    family_replacement: 'AppleMail'
+    family_replacement: 'Apple Mail'
 
   # AFTER THE EDGE CASES ABOVE!
   # AFTER IE11

--- a/test_resources/pgts_browser_list.yaml
+++ b/test_resources/pgts_browser_list.yaml
@@ -74989,13 +74989,13 @@ test_cases:
     patch:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko)'
-    family: 'AppleMail'
+    family: 'Apple Mail'
     major: '412'
     minor: '6'
     patch: '2'
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; es-es) AppleWebKit/531.22.7 (KHTML, like Gecko)'
-    family: 'AppleMail'
+    family: 'Apple Mail'
     major: '531'
     minor: '22'
     patch: '7'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -877,7 +877,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/536.26.14 (KHTML, like Gecko)'
-    family: 'AppleMail'
+    family: 'Apple Mail'
     major: '536'
     minor: '26'
     patch: '14'


### PR DESCRIPTION
Apple Mail is never referred to as "AppleMail", just as Internet Explorer isn't "InternetExplorer". It is also counter to other user agent parsers. This PR simply makes this change.