### PR TITLE
Add Twitterbot to regexes.yaml & relevant test

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -17,6 +17,10 @@ user_agent_parsers:
   - regex: 'Google.*/\+/web/snippet'
     family_replacement: 'GooglePlusBot'
 
+  # Twitter
+  - regex: '(Twitterbot)/(\d+)\.(\d+)'
+    family_replacement: 'TwitterBot'
+
   # Bots Pattern '/name-0.0'
   - regex: '/((?:Ant-)?Nutch|[A-z]+[Bb]ot|[A-z]+[Ss]pider|Axtaris|fetchurl|Isara|ShopSalad|Tailsweep)[ \-](\d+)(?:\.(\d+)(?:\.(\d+))?)?'
   # Bots Pattern 'name/0.0'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -264,6 +264,12 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Twitterbot/1.0'
+    family: 'TwitterBot'
+    major: '1'
+    minor: '0'
+    patch:
+
   - user_agent_string: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.1pre) Gecko/20090717 Ubuntu/9.04 (jaunty) Shiretoko/3.5.1pre'
     family: 'Firefox (Shiretoko)'
     major: '3'


### PR DESCRIPTION
Adds Twitterbot to regexes.yaml in its own family. User-agent string per documentation here: https://dev.twitter.com/cards/getting-started and observation in the wild.