### PR TITLE
update XiaoMi regex

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -3864,7 +3864,7 @@ device_parsers:
   # XiaoMi
   # @ref: http://www.xiaomi.com/event/buyphone
   #########
-  - regex: '; *((MI|HM|MI-ONE|Redmi)[ -](NOTE |Note )?[^;/]*) Build/'
+  - regex: '; *((MI|HM|MI-ONE|Redmi)[ -](NOTE |Note )?[^;/]*) (Build|MIUI)/'
     device_replacement: 'XiaoMi $1'
     brand_replacement: 'XiaoMi'
     model_replacement: '$1'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -79780,3 +79780,63 @@ test_cases:
     brand: 'Generic_Inettv'
     model: 'Roku'
 
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.2; MI PAD MIUI/KXFCNBF2.0)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.2; MI PAD MIUI/KXFCNBF3.0)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.2; MI PAD MIUI/KXFCNBF5.0)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/4.11.28)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/4.12.19)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/4.8.22)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.1.16)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.1.23)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.1.9)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.10.22)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.10.8)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.11.1)'
+    family: 'XiaoMi MI PAD'
+    brand: 'XiaoMi'
+    model: 'MI PAD'
+


### PR DESCRIPTION
update regex to be able to parse UA string like:
Dalvik/1.6.0 (Linux; U; Android 4.4.2; MI PAD MIUI/KXFCNBF2.0)
Dalvik/1.6.0 (Linux; U; Android 4.4.2; MI PAD MIUI/KXFCNBF3.0)
Dalvik/1.6.0 (Linux; U; Android 4.4.2; MI PAD MIUI/KXFCNBF5.0)
Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/4.11.28)
Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/4.12.19)
Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/4.8.22)
Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.1.16)
Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.1.23)
Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.1.9)
Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.10.22)
Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.10.8)
Dalvik/1.6.0 (Linux; U; Android 4.4.4; MI PAD MIUI/5.11.1)