### PR TITLE
Fix Thunderbird detection

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -309,7 +309,7 @@ user_agent_parsers:
   - regex: '(Airmail) (\d+)\.(\d+)(?:\.(\d+))?'
 
   # Thunderbird
-  - regex: '(Thunderbird)/(\d+)\.(\d+)\.(\d+(?:pre)?)'
+  - regex: '(Thunderbird)/(\d+)\.(\d+)(?:\.(\d+(?:pre)?))?'
     family_replacement: 'Thunderbird'
 
   # Vivaldi uses "Vivaldi"

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -784,6 +784,13 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Thunderbird/45.0'
+    family: 'Windows 7'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.3a1) Gecko/20100208 MozillaDeveloperPreview/3.7a1 (.NET CLR 3.5.30729)'
     family: 'Windows 7'
     major:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -864,6 +864,12 @@ test_cases:
     minor: '2'
     patch: '0'
 
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Thunderbird/45.0'
+    family: 'Thunderbird'
+    major: '45'
+    minor: '0'
+    patch:
+
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; MSOffice 12)'
     family: 'Outlook'
     major: '2007'


### PR DESCRIPTION
Patch version (user_agent_parsers) for Thunderbird should be optional.

Examples:
Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Thunderbird/45.0
Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:45.0) Gecko/20100101 Thunderbird/45.0