### PR TITLE
Gmail User Agent

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -17,6 +17,10 @@ user_agent_parsers:
   - regex: 'Google.*/\+/web/snippet'
     family_replacement: 'GooglePlusBot'
 
+  # Gmail
+  - regex: 'via ggpht.com GoogleImageProxy'
+    family_replacement: 'GmailImageProxy'
+
   # Twitter
   - regex: '(Twitterbot)/(\d+)\.(\d+)'
     family_replacement: 'TwitterBot'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -264,6 +264,12 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Firefox/11.0 (via ggpht.com GoogleImageProxy)'
+    family: 'GmailImageProxy'
+    major:
+    minor:
+    patch:
+
   - user_agent_string: 'Twitterbot/1.0'
     family: 'TwitterBot'
     major: '1'


### PR DESCRIPTION
In contrast to any other webmail application the client browser does not load any picture within an email directly from the destination server. Since 2013 the client browsers requests the image from the "Gmail Image Proxy" hich loads the image and therefore protects the user's privacy by hiding it's ip address.