### PR TITLE
adds Enseo and LG set top box browser user agent headers

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -506,6 +506,14 @@ user_agent_parsers:
   - regex: '(AppleWebKit)/(\d+)\.?(\d+)?\+ .* Safari'
     family_replacement: 'WebKit Nightly'
 
+  # LG
+  - regex: 'Mozilla\/\d+\.\d+ \((Web0S); .*\) .* Large Screen WebAppManager Safari\/\d+\.\d+'
+    family_replacement: 'LG'
+
+  # Enseo
+  - regex: 'Mozilla\/\d+\.\d+ \(.*(Enseo)\/.*\) Apple.*Safari\/\d+.\d+'
+    family_replacement: 'Enseo'
+
   # Safari
   - regex: '(Version)/(\d+)\.(\d+)(?:\.(\d+))?.*Safari/'
     family_replacement: 'Safari'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -887,7 +887,7 @@ test_cases:
     major: '4'
     minor: '0'
     patch: '8'
-    
+
   - user_agent_string: 'Mozilla/4.0 (compatible; Lotus-Notes/6.0; Windows-NT)'
     family: 'Lotus Notes'
     major: '6'
@@ -5858,7 +5858,7 @@ test_cases:
     major:
     minor:
     patch:
-    
+
   - user_agent_string: 'Mozilla/5.0 (compatible; YoudaoBot-rts/1.0; http://www.youdao.com/help/webmaster/spider/; )'
     family: 'YoudaoBot'
     major:
@@ -6706,7 +6706,13 @@ test_cases:
     patch: '0'
 
   - user_agent_string: 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.41 (KHTML, like Gecko) Large Screen WebAppManager Safari/537.41'
-    family: 'Safari'
+    family: 'LG'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Linux mips; Enseo/HD3300) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36'
+    family: 'Enseo'
     major:
     minor:
     patch:


### PR DESCRIPTION
Trackjs shows incorrect browser for a couple set top boxes we work with, these regexs will resolve our issue.
