### PR TITLE
Fix Lightning detection to separate standalone and addon installation

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -160,7 +160,7 @@ user_agent_parsers:
 
   # Lightning (for Thunderbird)
   # http://www.mozilla.org/projects/calendar/lightning/
-  - regex: '(Lightning)/(\d+)\.(\d+)\.?((?:[ab]?\d+[a-z]*)|(?:\d*))'
+  - regex: 'Gecko/\d+ (Lightning)/(\d+)\.(\d+)\.?((?:[ab]?\d+[a-z]*)|(?:\d*))'
 
   # Swiftfox
   - regex: '(Firefox)/(\d+)\.(\d+)\.(\d+(?:pre)?) \(Swiftfox\)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -865,10 +865,10 @@ test_cases:
     patch: '5'
 
   - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; rv:24.0) Gecko/20100101 Thunderbird/24.2.0 Lightning/2.6.4'
-    family: 'Lightning'
-    major: '2'
-    minor: '6'
-    patch: '4'
+    family: 'Thunderbird'
+    major: '24'
+    minor: '2'
+    patch: '0'
 
   - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; rv:24.0) Gecko/20100101 Thunderbird/24.2.0'
     family: 'Thunderbird'


### PR DESCRIPTION
If Lightning is installed as an addon to Thunderbird it is appended to Thunderbird's user agent and should not be used as detection for a Lightning agent. But if it's a standalone product the Lightning identifer directly follows the Gecko identifier:

* addon: `Mozilla/5.0 (X11; Linux x86_64; rv:24.0) Gecko/20100101 Thunderbird/24.2.0 Lightning/2.6.4`
* standalone: `Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2.17) Gecko/20110414 Lightning/1.0b3pre Thunderbird/3.1.10`