### PR TITLE
Add regex for PingdomTMS user agent

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -8,6 +8,9 @@ user_agent_parsers:
   # Pingdom
   - regex: '(Pingdom.com_bot_version_)(\d+)\.(\d+)'
     family_replacement: 'PingdomBot'
+    # 'Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34'
+  - regex: '(PingdomTMS)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'PingdomBot'
 
   # Facebook
   - regex: '(facebookexternalhit)/(\d+)\.(\d+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -786,6 +786,12 @@ test_cases:
     minor: '4'
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34'
+    family: 'PingdomBot'
+    major: '0'
+    minor: '8'
+    patch: '5'
+
   - user_agent_string: 'Mozilla/3.0 (Planetweb/2.100 JS SSL US; Dreamcast US)'
     family: 'Planetweb'
     major: '2'


### PR DESCRIPTION
We've been using Pingdom for a while and in the middle of October 2016 started seeing user agent strings that look like `Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34`.