### PR TITLE
Update Pale Moon regex

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -66,9 +66,11 @@ user_agent_parsers:
   - regex: '\[(Pinterest)/[^\]]+\]'
   - regex: '(Pinterest)(?: for Android(?: Tablet)?)?/(\d+)(?:\.(\d+)(?:\.(\d)+)?)?'
 
+  # Pale Moon
+  - regex: '(PaleMoon)/(\d+)\.(\d+)\.?(\d+)?'
+    family_replacement: 'Pale Moon'
+
   # Firefox
-  - regex: '(Pale[Mm]oon)/(\d+)\.(\d+)\.?(\d+)?'
-    family_replacement: 'Pale Moon (Firefox Variant)'
   - regex: '(Fennec)/(\d+)\.(\d+)\.?([ab]?\d+[a-z]*)'
     family_replacement: 'Firefox Mobile'
   - regex: '(Fennec)/(\d+)\.(\d+)(pre)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -769,10 +769,28 @@ test_cases:
     patch: '2'
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 5.1; rv:2.0) Gecko/20110407 Firefox/4.0.3 PaleMoon/4.0.3'
-    family: 'Pale Moon (Firefox Variant)'
+    family: 'Pale Moon'
     major: '4'
     minor: '0'
     patch: '3'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; rv:3.0) Goanna/20170207 PaleMoon/27.1.0'
+    family: 'Pale Moon'
+    major: '27'
+    minor: '1'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; rv:3.0) Gecko/20100101 Goanna/20170207 PaleMoon/27.1.0'
+    family: 'Pale Moon'
+    major: '27'
+    minor: '1'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; rv:45.9) Gecko/20100101 Goanna/3.0 Firefox/45.9 PaleMoon/27.1.0'
+    family: 'Pale Moon'
+    major: '27'
+    minor: '1'
+    patch: '0'
 
   - user_agent_string: 'Mozilla/5.0 (LG-T500 AppleWebkit/531 Browser/Phantom/V2.0 Widget/LGMW/3.0 MMS/LG-MMS-V1.0/1.2 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1)'
     family: 'Phantom Browser'


### PR DESCRIPTION
Pale Moon does not consider itself a “Firefox variant”, though it is a descendant of Firefox. From FAQ: “Pale Moon is a completely separate product with its own roadmap, direction, versioning and release schedule, unlike all other »Firefox-based« browsers out there.”

Current versions allow choosing one of the three “user agent modes” which differ only by the UA string:

* native;
* Gecko compatibility;
* Firefox compatibility.