### PR TITLE
Add Headless Chrome detection

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -354,6 +354,12 @@ user_agent_parsers:
   # @ref: http://www.dolphin.com
   - regex: '\b(Dolphin)(?: |HDCN/|/INT\-)(\d+)\.(\d+)\.?(\d+)?'
 
+  # Headless Chrome
+  # https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
+  # Currently only available on Linux
+  - regex: 'HeadlessChrome'
+    family_replacement: 'HeadlessChrome'
+
   # Browser/major_version.minor_version
   - regex: '(bingbot|Bolt|AdobeAIR|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin|qutebrowser|Otter|QupZilla|MailBar|kmail2|YahooMobileMail|ExchangeWebServices|ExchangeServicesClient|Dragon|Outlook-iOS-Android)/(\d+)\.(\d+)(?:\.(\d+))?'
 

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -6621,6 +6621,12 @@ test_cases:
     minor: '7'
     patch: '10'
 
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome Safari/537.36'
+    family: 'HeadlessChrome'
+    major:
+    minor:
+    patch:
+
   - user_agent_string: 'Roku/DVP-6.2 (096.02E06005A)'
     family: 'Roku'
     major: '6'


### PR DESCRIPTION
Although Headless Chrome is just a `--headless` flag for Chrome, the
user-agent is different, so we can treat it as a special browser.

This flag is only available on Linux for now, and the UA has no version
included.

Related with: https://github.com/karma-runner/karma/issues/2603