### PR TITLE
Handle device match for Huawei EVA-AL10

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -2129,7 +2129,7 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'Huawei'
     model_replacement: '$1'
-  - regex: '; *([^;]+) Build/Huawei'
+  - regex: '; *([^;]+) Build/(?:Huawei|HUAWEI)'
     device_replacement: '$1'
     brand_replacement: 'Huawei'
     model_replacement: '$1'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -79950,3 +79950,8 @@ test_cases:
     brand: 'Spider'
     model: 'Desktop'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; EVA-AL10 Build/HUAWEIEVA-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36'
+    family: 'EVA-AL10'
+    brand: 'Huawei'
+    model: 'EVA-AL10'
+


### PR DESCRIPTION
This fixes the device identification for the Huawei EVA-AL10.  I found the user agent string in the wild.