### PR TITLE
Keep OS X CFNetwork from being identified as iOS

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -871,6 +871,10 @@ os_parsers:
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '10'
+  - regex: '(CF)(Network)/(760)\.(\d)'
+    os_replacement: 'Mac OS X'
+    os_v1_replacement: '10'
+    os_v2_replacement: '11'
   - regex: '(CF)(Network)/758\.(\d)'
     os_replacement: 'iOS'
     os_v1_replacement: '9'
@@ -878,6 +882,18 @@ os_parsers:
     os_replacement: 'iOS'
     os_v1_replacement: '10'
 
+  ##########
+  # CFNetwork macOS Apps (must be before CFNetwork iOS Apps
+  # @ref: https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
+  ##########
+  - regex: 'CFNetwork/.* Darwin/16\.\d+.*\(x86_64\)'
+    os_replacement: 'Mac OS X'
+    os_v1_replacement: '10'
+    os_v2_replacement: '12'
+  - regex: 'CFNetwork/8.* Darwin/15\.\d+.*\(x86_64\)'
+    os_replacement: 'Mac OS X'
+    os_v1_replacement: '10'
+    os_v2_replacement: '11'
   ##########
   # CFNetwork iOS Apps
   # @ref: https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
@@ -4430,6 +4446,9 @@ device_parsers:
     device_replacement: '$1$2,$3'
     brand_replacement: 'Apple'
     model_replacement: '$1$2,$3'
+  # @note: newer desktop applications don't show device info
+  # This is here so as to not have them recorded as iOS-Device
+  - regex: 'CFNetwork/.* Darwin/\d+\.\d+\.\d+ \(x86_64\)'
   # @note: iOS applications do not show device info
   - regex: 'CFNetwork/.* Darwin/\d'
     device_replacement: 'iOS-Device'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -79950,3 +79950,12 @@ test_cases:
     brand: 'Spider'
     model: 'Desktop'
 
+  - user_agent_string: 'MobileSafari/602.1 CFNetwork/808.1.4 Darwin/16.1.0'
+    family: 'iOS-Device'
+    brand: 'Apple'
+    model: 'iOS-Device'
+
+  - user_agent_string: 'Safari/12602.2.14.0.7 CFNetwork/807.1.3 Darwin/16.1.0 (x86_64)'
+    family: 'Other'
+    brand:
+    model:

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2335,3 +2335,9 @@ test_cases:
     patch: '6'
     patch_minor:
 
+  - user_agent_string: 'Safari/12602.2.14.0.7 CFNetwork/807.1.3 Darwin/16.1.0 (x86_64)'
+    family: 'Mac OS X'
+    major: '10'
+    minor: '12'
+    patch:
+    patch_minor:


### PR DESCRIPTION
Some newer CFNetwork applications on OS X were being detected as running iOS and/or being an iOS-Device.  This prevents those false detections.