### PR TITLE
Explicitly set device_replacement for CFNetwork desktop devices

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -4453,6 +4453,7 @@ device_parsers:
   # @note: newer desktop applications don't show device info
   # This is here so as to not have them recorded as iOS-Device
   - regex: 'CFNetwork/.* Darwin/\d+\.\d+\.\d+ \(x86_64\)'
+    device_replacement: 'Other'
   # @note: iOS applications do not show device info
   - regex: 'CFNetwork/.* Darwin/\d'
     device_replacement: 'iOS-Device'


### PR DESCRIPTION
The implicit assumption that this regex with no child properties
will stop further matches causess issues in downstream uap-scala:
https://github.com/ua-parser/uap-scala/pull/16 which depends on
regexes having explicitly defined properties. Since this seems
to be the only regex rule which behaves in this manner it appears
appropriate to explicitly call out the device_replacement as it is
expected in the test_device.yaml