### PR TITLE
Support for Coc Coc

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -232,6 +232,10 @@ user_agent_parsers:
   - regex: '(SamsungBrowser)/(\d+)\.(\d+)'
     family_replacement: 'Samsung Internet'
 
+  # Coc Coc browser, based on Chrome (used in Vietnam)
+  - regex: '(coc_coc_browser)/(\d+)\.(\d+)(?:\.(\d+))?'
+    family_replacement: 'Coc Coc'
+
   # Baidu Browsers (desktop spoofs chrome & IE, explorer is mobile)
   - regex: '(baidubrowser)[/\s](\d+)(?:\.(\d+)(?:\.(\d+))?)?'
     family_replacement: 'Baidu Browser'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7046,3 +7046,21 @@ test_cases:
     major: '1'
     minor: '0'
     patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/42.0 CoRom/36.0.1985.144 Chrome/36.0.1985.144 Safari/537.36'
+    family: 'Coc Coc'
+    major: '42'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/49.0 Chrome/43.0.2357.138 Safari/537.36'
+    family: 'Coc Coc'
+    major: '49'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/50.0.125 Chrome/44.0.2403.125 Safari/537.36'
+    family: 'Coc Coc'
+    major: '50'
+    minor: '0'
+    patch: '125'


### PR DESCRIPTION
Coc Coc is a fairly popular Vietnamese browser, it's based on Chrome. It used to contain a major and a minor version, it now includes a patch number as well (so I made it optional in my regex, to be backwards compatible).

I saw dozens of thousands of hits from this browser in our logs, but I took the test UA values [from here](http://www.webapps-online.com/online-tools/user-agent-strings/dv/browser640754/coc-coc-browser).

(Tests passing on my laptop.)