### PR TITLE
Parse Headless Chrome versions

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -419,9 +419,7 @@ user_agent_parsers:
 
   # Headless Chrome
   # https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
-  # Currently only available on Linux
-  - regex: 'HeadlessChrome'
-    family_replacement: 'HeadlessChrome'
+  - regex: '(HeadlessChrome)(?:/(\d+)\.(\d+)\.(\d+))?'
 
   # Browser/major_version.minor_version
   - regex: '(bingbot|Bolt|AdobeAIR|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin|qutebrowser|Otter|QupZilla|MailBar|kmail2|YahooMobileMail|ExchangeWebServices|ExchangeServicesClient|Dragon|Outlook-iOS-Android)/(\d+)\.(\d+)(?:\.(\d+))?'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -6699,6 +6699,18 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/62.0.3202.89 Safari/537.36'
+    family: 'HeadlessChrome'
+    major: '62'
+    minor: '0'
+    patch: '3202'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/59.0.3071.109 HeadlessChrome/59.0.3071.109 Safari/537.36'
+    family: 'HeadlessChrome'
+    major: '59'
+    minor: '0'
+    patch: '3071'
+
   - user_agent_string: 'Roku/DVP-6.2 (096.02E06005A)'
     family: 'Roku'
     major: '6'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -2373,6 +2373,12 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Safari/537.36'
+    family: 'Chrome'
+    major: '60'
+    minor: '0'
+    patch: '3112'
+
   - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko; Google Web Preview) Chrome/27.0 .1453 Safari/537.36.'
     family: 'Chrome'
     major: '27'


### PR DESCRIPTION
The initial implementation of the Headless Chrome detection (#228) didn't detect
versions of the headless version. This has been fixed.

A test for Ubuntu Chromium in headless mode was also added. I haven't made it
recognized as HeadlessChromium as it has HeadlessChrome in the user agent. It
might be worthwhile to check how a pure compiled from source Chromium behaves.
Nevertheless, this commit is still an improvement.

Also, a test for a bare Chrome 60 instance was added.

This PR is needed to resolve https://github.com/karma-runner/karma/issues/2762