### PR TITLE
Add support for Box Drive, Sync, and Notes

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -335,6 +335,10 @@ user_agent_parsers:
   # Podcast catcher Applications using iTunes
   - regex: '(PodCruncher|Downcast)[ /]?(\d+)\.?(\d+)?\.?(\d+)?\.?(\d+)?'
 
+  # Box Notes https://www.box.com/resources/downloads
+  # Must be before Electron
+  - regex: ' (BoxNotes)/(\d+)\.(\d+)\.(\d+)'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####
@@ -689,6 +693,8 @@ user_agent_parsers:
   - regex: '(Kurio)\/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Kurio App'
 
+  # Box Drive and Box Sync https://www.box.com/resources/downloads
+  - regex: '^(Box(?: Sync)?)/(\d+)\.(\d+)\.(\d+)'
 
 os_parsers:
   ##########
@@ -870,6 +876,10 @@ os_parsers:
   - regex: 'Win32'
     os_replacement: 'Windows 95'
 
+  # Box apps (Drive, Sync, Notes) on Windows https://www.box.com/resources/downloads
+  - regex: '^Box.*Windows/([\d.]+);'
+    os_replacement: 'Windows $1'
+
   ##########
   # Tizen OS from Samsung
   # spoofs Android so pushing it above
@@ -919,6 +929,10 @@ os_parsers:
 
   # ios devices spoof (mac os x), so including intel/ppc prefixes
   - regex: '(?:PPC|Intel) (Mac OS X)'
+
+  # Box Drive and Box Sync on Mac OS X use OSX version numbers, not Darwin
+  - regex: '^Box.*;(Darwin)/(10)\.(1\d)(?:\.(\d+))?'
+    os_replacement: 'Mac OS X'
 
   ##########
   # iOS

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2348,3 +2348,59 @@ test_cases:
     minor: '12'
     patch:
     patch_minor:
+
+  - user_agent_string: 'Box Sync/4.0.7848;Darwin/10.13;i386/64bit'
+    family: 'Mac OS X'
+    major: '10'
+    minor: '13'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Box/1.2.93;Darwin/10.13;i386/64bit'
+    family: 'Mac OS X'
+    major: '10'
+    minor: '13'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_0) AppleWebKit/537.36 (KHTML, like Gecko) BoxNotes/1.3.0 Chrome/56.0.2924.87 Electron/1.6.8 Safari/537.36'
+    family: 'Mac OS X'
+    major: '10'
+    minor: '13'
+    patch: '0'
+    patch_minor:
+
+  - user_agent_string: 'Box Sync/4.0.7848;Windows/8.1;x86 Family 6 Model 158 Stepping 9, GenuineIntel/32bit'
+    family: 'Windows 8.1'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Box Sync/4.0.7848;Windows/10;Intel64 Family 6 Model 158 Stepping 9, GenuineIntel/64bit'
+    family: 'Windows 10'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) BoxNotes/1.3.0 Chrome/56.0.2924.87 Electron/1.6.8 Safari/537.36'
+    family: 'Windows 8.1'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) BoxNotes/1.3.0 Chrome/56.0.2924.87 Electron/1.6.8 Safari/537.36'
+    family: 'Windows 10'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Box/1.2.93;Windows/10;Intel64 Family 6 Model 158 Stepping 9, GenuineIntel/64bit'
+    family: 'Windows 10'
+    major:
+    minor:
+    patch:
+    patch_minor:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7222,3 +7222,50 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Box Sync/4.0.7848;Darwin/10.13;i386/64bit'
+    family: 'Box Sync'
+    major: '4'
+    minor: '0'
+    patch: '7848'
+
+  - user_agent_string: 'Box/1.2.93;Darwin/10.13;i386/64bit'
+    family: 'Box'
+    major: '1'
+    minor: '2'
+    patch: '93'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_0) AppleWebKit/537.36 (KHTML, like Gecko) BoxNotes/1.3.0 Chrome/56.0.2924.87 Electron/1.6.8 Safari/537.36'
+    family: 'BoxNotes'
+    major: '1'
+    minor: '3'
+    patch: '0'
+
+  - user_agent_string: 'Box Sync/4.0.7848;Windows/8.1;x86 Family 6 Model 158 Stepping 9, GenuineIntel/32bit'
+    family: 'Box Sync'
+    major: '4'
+    minor: '0'
+    patch: '7848'
+
+  - user_agent_string: 'Box Sync/4.0.7848;Windows/10;Intel64 Family 6 Model 158 Stepping 9, GenuineIntel/64bit'
+    family: 'Box Sync'
+    major: '4'
+    minor: '0'
+    patch: '7848'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) BoxNotes/1.3.0 Chrome/56.0.2924.87 Electron/1.6.8 Safari/537.36'
+    family: 'BoxNotes'
+    major: '1'
+    minor: '3'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) BoxNotes/1.3.0 Chrome/56.0.2924.87 Electron/1.6.8 Safari/537.36'
+    family: 'BoxNotes'
+    major: '1'
+    minor: '3'
+    patch: '0'
+
+  - user_agent_string: 'Box/1.2.93;Windows/10;Intel64 Family 6 Model 158 Stepping 9, GenuineIntel/64bit'
+    family: 'Box'
+    major: '1'
+    minor: '2'
+    patch: '93'


### PR DESCRIPTION
- Add support for these 3 user agents. Prior to this change, Box Notes was detected as Electron.
- Box Drive and Box Sync supply OS information in an unusual manner, so add special casing for them.
