### PR TITLE
Removing node 0.12 as mocha4 discontinued support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - 0.12
   - 4
+  - 6
+  - 8
   - node
 
 script:


### PR DESCRIPTION
PR addressing Issue #274
- Removes node 0.12 as mocha4 discontinued support
- Adds node v6.x and v8.x

