### PR TITLE
Add several agents related to Nextcloud

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -532,6 +532,11 @@ user_agent_parsers:
   - regex: '(MSIE) (\d+)\.(\d+).*XBLWP7'
     family_replacement: 'IE Large Screen'
 
+  # Nextcloud desktop sync client
+  - regex: '(Nextcloud)'
+
+  # Generic mirall client
+  - regex: '(mirall)/(\d+)\.(\d+)\.(\d+)'
 
   #### END MAIN CASES ####
 

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -66,6 +66,9 @@ user_agent_parsers:
   - regex: '(MSIE) (\d+)\.(\d+)([a-z]\d?)?;.* MSIECrawler'
     family_replacement: 'MSIECrawler'
 
+  # DAVdroid
+  - regex: '(DAVdroid)/(\d+)\.(\d+)\.(\d+(?:-gplay))'
+
   # Downloader ...
   - regex: '(Google-HTTP-Java-Client|Apache-HttpClient|http%20client|Python-urllib|HttpMonitor|TLSProber|WinHTTP|JNLP|okhttp)(?:[ /](\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
 

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -424,6 +424,9 @@ user_agent_parsers:
   # Evolution Mail CardDav/CalDav integration
   - regex: '(Evolution)/(\d+)\.(\d+)\.(\d+\.\d+)'
 
+  # Roundcube Mail CardDav plugin
+  - regex: '(RCM CardDAV plugin)/(\d+)\.(\d+)\.(\d+(?:-dev)?)'
+
   # Browser/major_version.minor_version
   - regex: '(bingbot|Bolt|AdobeAIR|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin|qutebrowser|Otter|QupZilla|MailBar|kmail2|YahooMobileMail|ExchangeWebServices|ExchangeServicesClient|Dragon|Outlook-iOS-Android)/(\d+)\.(\d+)(?:\.(\d+))?'
 

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -67,7 +67,7 @@ user_agent_parsers:
     family_replacement: 'MSIECrawler'
 
   # DAVdroid
-  - regex: '(DAVdroid)/(\d+)\.(\d+)\.(\d+(?:-gplay))'
+  - regex: '(DAVdroid)/(\d+)\.(\d+)(?:\.(\d+))?'
 
   # Downloader ...
   - regex: '(Google-HTTP-Java-Client|Apache-HttpClient|http%20client|Python-urllib|HttpMonitor|TLSProber|WinHTTP|JNLP|okhttp)(?:[ /](\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -538,6 +538,10 @@ user_agent_parsers:
   # Generic mirall client
   - regex: '(mirall)/(\d+)\.(\d+)\.(\d+)'
 
+  # Nextcloud/Owncloud android client
+  - regex: '(ownCloud-android)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Owncloud'
+
   #### END MAIN CASES ####
 
   #### SPECIAL CASES ####

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -421,6 +421,9 @@ user_agent_parsers:
   # https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
   - regex: '(HeadlessChrome)(?:/(\d+)\.(\d+)\.(\d+))?'
 
+  # Evolution Mail CardDav/CalDav integration
+  - regex: '(Evolution)/(\d+)\.(\d+)\.(\d+\.\d+)'
+
   # Browser/major_version.minor_version
   - regex: '(bingbot|Bolt|AdobeAIR|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin|qutebrowser|Otter|QupZilla|MailBar|kmail2|YahooMobileMail|ExchangeWebServices|ExchangeServicesClient|Dragon|Outlook-iOS-Android)/(\d+)\.(\d+)(?:\.(\d+))?'
 

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -79999,3 +79999,8 @@ test_cases:
     family: 'Gionee GN3003'
     brand: 'Gionee'
     model: 'GN3003'
+
+  - user_agent_string: 'Mozilla/5.0 (Android) ownCloud-android/2.0.0'
+    family: 'Generic Smartphone'
+    brand: 'Generic'
+    model: 'Smartphone'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -1074,6 +1074,13 @@ test_cases:
     patch: '4'
     patch_minor:
 
+  - user_agent_string: 'DAVdroid/1.9.2-gplay (2017/11/04; dav4android; okhttp3) Android/7.1.2'
+    family: 'Android'
+    major: '7'
+    minor: '1'
+    patch: '2'
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (SymbianOS 9.4; Series60/5.0 NokiaN97-1/10.0.012; Profile/MIDP-2.1 Configuration/CLDC-1.1; en-us) AppleWebKit/525 (KHTML, like Gecko) WicKed/7.1.12344'
     family: 'Symbian OS'
     major: '9'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2411,3 +2411,17 @@ test_cases:
     minor:
     patch:
     patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows) mirall/2.3.2 (build 1) (Nextcloud)'
+    family: 'Windows'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux) mirall/2.3.2 (Nextcloud)'
+    family: 'Linux'
+    major:
+    minor:
+    patch:
+    patch_minor:

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2425,3 +2425,10 @@ test_cases:
     minor:
     patch:
     patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Android) ownCloud-android/2.0.0'
+    family: 'Android'
+    major:
+    minor:
+    patch:
+    patch_minor:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7310,4 +7310,10 @@ test_cases:
     family: 'DAVdroid'
     major: '1'
     minor: '9'
-    patch: '2-gplay'
+    patch: '2'
+
+  - user_agent_string: 'DAVdroid/1.9-ose (2017/10/19; dav4android; okhttp3) Android/7.1.2'
+    family: 'DAVdroid'
+    major: '1'
+    minor: '9'
+    patch:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7329,3 +7329,9 @@ test_cases:
     major:
     minor:
     patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Android) ownCloud-android/2.0.0'
+    family: 'Owncloud'
+    major: '2'
+    minor: '0'
+    patch: '0'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7293,3 +7293,15 @@ test_cases:
     major: '3'
     minor: '26'
     patch: '2.1'
+
+  - user_agent_string: 'RCM CardDAV plugin/2.0.4'
+    family: 'RCM CardDAV plugin'
+    major: '2'
+    minor: '0'
+    patch: '4'
+
+  - user_agent_string: 'RCM CardDAV plugin/0.9.2-dev'
+    family: 'RCM CardDAV plugin'
+    major: '0'
+    minor: '9'
+    patch: '2-dev'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7317,3 +7317,15 @@ test_cases:
     major: '1'
     minor: '9'
     patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows) mirall/2.3.2 (build 1) (Nextcloud)'
+    family: 'Nextcloud'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux) mirall/2.3.2 (Nextcloud)'
+    family: 'Nextcloud'
+    major:
+    minor:
+    patch:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7287,3 +7287,9 @@ test_cases:
     major: '1'
     minor: '2'
     patch: '93'
+
+  - user_agent_string: 'Evolution/3.26.2.1'
+    family: 'Evolution'
+    major: '3'
+    minor: '26'
+    patch: '2.1'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7305,3 +7305,9 @@ test_cases:
     major: '0'
     minor: '9'
     patch: '2-dev'
+
+  - user_agent_string: 'DAVdroid/1.9.2-gplay (2017/11/04; dav4android; okhttp3) Android/7.1.2'
+    family: 'DAVdroid'
+    major: '1'
+    minor: '9'
+    patch: '2-gplay'


### PR DESCRIPTION
- ab576d9 adds Evolution's user agent for "on the web" calendars and address books.
- 820bf4d adds Roundcube's CardDAV plugin. Prior to v0.9.0 (about three years ago) they used `RCM CardDAV plugin/TRUNK` between releases, not sure whether I should add that as well. After v0.9.0 they changed to a `-dev` suffix which I added to the regex.
- ff51462 adds the app DAVdroid. They use version suffixes depending on where you download the app (e.g. `1.9.2-gplay` on Google Play, `1.9-ose` on F-Droid), not sure if I should add these to the version output.
  I also had to put this quite high in the `SPECIAL CASES TOP` as they include OkHttp in their user agent which is matched as a "downloader..." (#185).
- 631c5e4 adds the Nextcloud desktop sync application. The Owncloud version could probably be added to that regex as well, but I don't have anything to test it with.
- 5aa11ba adds the official Nextcloud android app. Sadly the app didn't change it's user agent after forking from the Owncloud version so they still send `owncloud-android`.