### PR TITLE
Detect AppleNews with correct WebKit version

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -572,6 +572,8 @@ user_agent_parsers:
   # @note: iOS / OSX Applications
   - regex: '(iPod|iPhone|iPad).+Version/(\d+)\.(\d+)(?:\.(\d+))?.*[ +]Safari'
     family_replacement: 'Mobile Safari'
+  - regex: '(iPod|iPod touch|iPhone|iPad);.*CPU.*OS[ +](\d+)_(\d+)(?:_(\d+))?.* AppleNews\/\d+\.\d+\.\d+?'
+    family_replacement: 'Mobile Safari UI/WKWebView'
   - regex: '(iPod|iPhone|iPad).+Version/(\d+)\.(\d+)(?:\.(\d+))?'
     family_replacement: 'Mobile Safari UI/WKWebView'
   - regex: '(iPod|iPod touch|iPhone|iPad);.*CPU.*OS[ +](\d+)_(\d+)(?:_(\d+))?.*Mobile.*[ +]Safari'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7173,7 +7173,7 @@ test_cases:
     major: '3'
     minor: '8'
     patch: '4'
- 
+
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 SznProhlizec/4.4i'
     family: 'Seznam.cz'
     major: '4'
@@ -7335,3 +7335,9 @@ test_cases:
     major: '2'
     minor: '0'
     patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) AppleNews/608.0.1 Version/2.0.1'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '10'
+    minor: '0'
+    patch: '2'


### PR DESCRIPTION
Currently, uap-core detects the AppleNews user-agent string with the correct family but incorrect version.

I am using the useragent npm module to return the detections, that module uses uap-core under the hood.
```
Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) AppleNews/608.0.1 Version/2.0.1
```
Is detected as
```
Mobile Safari UI/WKWebView 2.0.1 / iOS 10.0.2
```

This PR aims to detect it as
```
Mobile Safari UI/WKWebView 10.0.2 / iOS 10.0.2
```