### PR TITLE
Fix windows family recognition

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "yamlparser": ">=0.0.2",
     "mocha": "*",
-    "uap-ref-impl": "git@github.com:theikkila/uap-ref-impl.git#65a6a3b8df233eecd20bc88ee22d3c0e3bb2512c"
+    "uap-ref-impl": "theikkila/uap-ref-impl"
   },
   "scripts": {
     "test": "mocha -u tdd -R min ./tests/test.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "yamlparser": ">=0.0.2",
     "mocha": "*",
-	"uap-ref-impl": "*"
+    "uap-ref-impl": "git@github.com:theikkila/uap-ref-impl.git#65a6a3b8df233eecd20bc88ee22d3c0e3bb2512c"
   },
   "scripts": {
     "test": "mocha -u tdd -R min ./tests/test.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "yamlparser": ">=0.0.2",
     "mocha": "*",
-    "uap-ref-impl": "*"
+    "uap-ref-impl": "ua-parser/uap-ref-impl"
   },
   "scripts": {
     "test": "mocha -u tdd -R min ./tests/test.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "yamlparser": ">=0.0.2",
     "mocha": "*",
-    "uap-ref-impl": "theikkila/uap-ref-impl"
+    "uap-ref-impl": "*"
   },
   "scripts": {
     "test": "mocha -u tdd -R min ./tests/test.js"

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -4582,6 +4582,10 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'Apple'
     model_replacement: '$1'
+  - regex: 'iPhone'
+    device_replacement: 'iPhone'
+    brand_replacement: 'Apple'
+    model_replacement: 'iPhone'
   # @note: desktop applications show device info
   - regex: 'CFNetwork/.* Darwin/\d.*\(((?:Mac|iMac|PowerMac|PowerBook)[^\d]*)(\d+)(?:,|%2C)(\d+)'
     device_replacement: '$1$2,$3'

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -848,55 +848,75 @@ os_parsers:
     os_replacement: 'Windows Mobile'
 
   - regex: '(Windows (?:NT 5\.2|NT 5\.1))'
-    os_replacement: 'Windows XP'
+    os_replacement: 'Windows'
+    os_v1_replacement: 'XP'
 
   - regex: '(Windows NT 6\.1)'
-    os_replacement: 'Windows 7'
+    os_replacement: 'Windows'
+    os_v1_replacement: '7'
 
   - regex: '(Windows NT 6\.0)'
-    os_replacement: 'Windows Vista'
+    os_replacement: 'Windows'
+    os_v1_replacement: 'Vista'
 
   - regex: '(Win 9x 4\.90)'
-    os_replacement: 'Windows ME'
+    os_replacement: 'Windows'
+    os_v1_replacement: 'ME'
 
   - regex: '(Windows 98|Windows XP|Windows ME|Windows 95|Windows CE|Windows 7|Windows NT 4\.0|Windows Vista|Windows 2000|Windows 3.1)'
 
   - regex: '(Windows NT 6\.2; ARM;)'
-    os_replacement: 'Windows RT'
+    os_replacement: 'Windows'
+    os_v1_replacement: 'RT'
+
   - regex: '(Windows NT 6\.2)'
-    os_replacement: 'Windows 8'
+    os_replacement: 'Windows'
+    os_v1_replacement: '8'
 
   - regex: '(Windows NT 6\.3; ARM;)'
-    os_replacement: 'Windows RT 8.1'
+    os_replacement: 'Windows'
+    os_v1_replacement: 'RT 8.1'
+
   - regex: '(Windows NT 6\.3)'
-    os_replacement: 'Windows 8.1'
+    os_replacement: 'Windows'
+    os_v1_replacement: '8.1'
 
   - regex: '(Windows NT 6\.4)'
-    os_replacement: 'Windows 10'
+    os_replacement: 'Windows'
+    os_v1_replacement: '10'
+
   - regex: '(Windows NT 10\.0)'
-    os_replacement: 'Windows 10'
+    os_replacement: 'Windows'
+    os_v1_replacement: '10'
 
   - regex: '(Windows NT 5\.0)'
-    os_replacement: 'Windows 2000'
+    os_replacement: 'Windows'
+    os_v1_replacement: '2000'
 
   - regex: '(WinNT4.0)'
-    os_replacement: 'Windows NT 4.0'
+    os_replacement: 'Windows'
+    os_v1_replacement: 'NT 4.0'
 
   - regex: '(Windows ?CE)'
-    os_replacement: 'Windows CE'
+    os_replacement: 'Windows'
+    os_v1_replacement: 'CE'
 
   - regex: 'Win ?(95|98|3.1|NT|ME|2000)'
-    os_replacement: 'Windows $1'
+    os_replacement: 'Windows'
+    os_v1_replacement: '$1'
 
   - regex: 'Win16'
-    os_replacement: 'Windows 3.1'
+    os_replacement: 'Windows'
+    os_v1_replacement: '3.1'
 
   - regex: 'Win32'
-    os_replacement: 'Windows 95'
+    os_replacement: 'Windows'
+    os_v1_replacement: '95'
 
   # Box apps (Drive, Sync, Notes) on Windows https://www.box.com/resources/downloads
   - regex: '^Box.*Windows/([\d.]+);'
-    os_replacement: 'Windows $1'
+    os_replacement: 'Windows'
+    os_v1_replacement: '$1'
 
   ##########
   # Tizen OS from Samsung

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -361,9 +361,9 @@ test_cases:
     model:
 
   - user_agent_string: 'MQQBrowser/371 Mozilla/5.0 (iPhone 4S; CPU iPhone OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10A523 Safari/7534.48.3'
-    family: 'Generic Smartphone'
-    brand: 'Generic'
-    model: 'Smartphone'
+    family: 'iPhone'
+    brand: 'Apple'
+    model: 'iPhone'
 
   - user_agent_string: 'Opera/9.80 (VRE; Opera Mini/4.2/28.2794; U; en) Presto/2.8.119 Version/11.10'
     family: 'Generic Feature Phone'
@@ -79999,6 +79999,11 @@ test_cases:
     family: 'Gionee GN3003'
     brand: 'Gionee'
     model: 'GN3003'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone## CPU iPhone OS 10_2 like Mac OS X) AppleWebKit/602.3.12 (KHTML, like Gecko) Mobile/14C92'
+    family: 'iPhone'
+    brand: 'Apple'
+    model: 'iPhone'
 
   - user_agent_string: 'Mozilla/5.0 (Android) ownCloud-android/2.0.0'
     family: 'Generic Smartphone'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -743,92 +743,92 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko'
-    family: 'Windows 10'
-    major:
+    family: 'Windows'
+    major: '10'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0'
-    family: 'Windows 10'
-    major:
+    family: 'Windows'
+    major: '10'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.4; Trident/7.0; rv:11.0) like Gecko'
-    family: 'Windows 10'
-    major:
+    family: 'Windows'
+    major: '10'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36 Edge/12.0'
-    family: 'Windows 10'
-    major:
+    family: 'Windows'
+    major: '10'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.4; WOW64; rv:36.0) Gecko/20100101 Firefox/36.0'
-    family: 'Windows 10'
-    major:
+    family: 'Windows'
+    major: '10'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'
-    family: 'Windows 8.1'
-    major:
+    family: 'Windows'
+    major: '8.1'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; ARM; WOW64; Trident/7.0; rv:11.0) like Gecko'
-    family: 'Windows RT 8.1'
-    major:
+    family: 'Windows'
+    major: 'RT 8.1'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.17) Gecko/20110414 Thunderbird/3.1.10 ThunderBrowse/3.3.5'
-    family: 'Windows 7'
-    major:
+    family: 'Windows'
+    major: '7'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Thunderbird/45.0'
-    family: 'Windows 7'
-    major:
+    family: 'Windows'
+    major: '7'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.3a1) Gecko/20100208 MozillaDeveloperPreview/3.7a1 (.NET CLR 3.5.30729)'
-    family: 'Windows 7'
-    major:
+    family: 'Windows'
+    major: '7'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) FireWeb/1.0.0.0'
-    family: 'Windows 7'
-    major:
+    family: 'Windows'
+    major: '7'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; zh_CN) AppleWebKit/534.7 (KHTML, like Gecko) Chrome/7.0 baidubrowser/1.x Safari/534.7'
-    family: 'Windows 7'
-    major:
+    family: 'Windows'
+    major: '7'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; baidubrowser 1.x)'
-    family: 'Windows 7'
-    major:
+    family: 'Windows'
+    major: '7'
     minor:
     patch:
     patch_minor:
@@ -862,85 +862,85 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'
-    family: 'Windows 8'
-    major:
+    family: 'Windows'
+    major: '8'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0)'
-    family: 'Windows RT'
-    major:
+    family: 'Windows'
+    major: 'RT'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; chromeframe; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729)'
-    family: 'Windows Vista'
-    major:
+    family: 'Windows'
+    major: 'Vista'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2.17) Gecko/20110414 Lightning/1.0b3pre Thunderbird/3.1.10'
-    family: 'Windows XP'
-    major:
+    family: 'Windows'
+    major: 'XP'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Opera/9.80 (Windows NT 5.1; U; ru) Presto/2.5.24 Version/10.53'
-    family: 'Windows XP'
-    major:
+    family: 'Windows'
+    major: 'XP'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; BOLT/2.101) AppleWebKit/530  (KHTML, like Gecko) Version/4.0 Safari/530.17'
-    family: 'Windows XP'
-    major:
+    family: 'Windows'
+    major: 'XP'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; chromeframe; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; Sleipnir 2.8.5)3.0.30729)'
-    family: 'Windows XP'
-    major:
+    family: 'Windows'
+    major: 'XP'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB6; chromeframe; .NET CLR 2.0.50727; .NET CLR 1.1.4322; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)'
-    family: 'Windows XP'
-    major:
+    family: 'Windows'
+    major: 'XP'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB6; .NET CLR 2.0.50727; .NET CLR 1.1.4322)'
-    family: 'Windows XP'
-    major:
+    family: 'Windows'
+    major: 'XP'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/534.3 (KHTML, like Gecko) RockMelt/0.8.34.841 Chrome/6.0.472.63 Safari/534.3'
-    family: 'Windows XP'
-    major:
+    family: 'Windows'
+    major: 'XP'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Comodo_Dragon/4.1.1.11 Chrome/4.1.249.1042 Safari/532.5'
-    family: 'Windows XP'
-    major:
+    family: 'Windows'
+    major: 'XP'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 5.1; rv:2.0) Gecko/20110407 Firefox/4.0.3 PaleMoon/4.0.3'
-    family: 'Windows XP'
-    major:
+    family: 'Windows'
+    major: 'XP'
     minor:
     patch:
     patch_minor:
@@ -953,8 +953,8 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Win 9x 4.90; PL; rv:1.7.5) Gecko/20041217'
-    family: 'Windows ME'
-    major:
+    family: 'Windows'
+    major: 'ME'
     minor:
     patch:
     patch_minor:
@@ -1656,106 +1656,106 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows U; Win NT 5.0; en-US; rv:1.8.0.2) Gecko/20060308 Firefox/1.5.0.2'
-    family: 'Windows NT'
-    major:
+    family: 'Windows'
+    major: 'NT'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; N; WinNT; en-US; m14) Netscape6/6.0b1,gzip(gfe),gzip(gfe),gzip(gfe)'
-    family: 'Windows NT'
-    major:
+    family: 'Windows'
+    major: 'NT'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Win 9x 4.90; de; rv:1.8.1.7) Gecko/20070914 Firefox/2.0.0.7'
-    family: 'Windows ME'
-    major:
+    family: 'Windows'
+    major: 'ME'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Win 9x 4.90; en-CA; rv:0.9.4.1) Gecko/20020314 Netscape6/6.2.2'
-    family: 'Windows ME'
-    major:
+    family: 'Windows'
+    major: 'ME'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Win16; en-US; rv:1.7) Safari/85.5'
-    family: 'Windows 3.1'
-    major:
+    family: 'Windows'
+    major: '3.1'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Win3.1; en-US; rv:1.0.0) Gecko/20020530'
-    family: 'Windows 3.1'
-    major:
+    family: 'Windows'
+    major: '3.1'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Win3.11; en-US; rv:21.56.11.90) Gecko/20500230 Firefox/3.5'
-    family: 'Windows 3.1'
-    major:
+    family: 'Windows'
+    major: '3.1'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Win32; rv:1.6),gzip(gfe),gzip(gfe),gzip(gfe)'
-    family: 'Windows 95'
-    major:
+    family: 'Windows'
+    major: '95'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Win95; en-GB; rv:1.0.1) Gecko/20020823 Netscape/7.0'
-    family: 'Windows 95'
-    major:
+    family: 'Windows'
+    major: '95'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Win95; en-GB; rv:1.8.0.8) Gecko/20061025 Firefox/1.5.0.8'
-    family: 'Windows 95'
-    major:
+    family: 'Windows'
+    major: '95'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; WindowsCE 5.2; en-US; rv:1.9.2a2pre) Gecko/20090904 Fennec/1.0a3'
-    family: 'Windows CE'
-    major:
+    family: 'Windows'
+    major: 'CE'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (WindowsCE 6.0; rv:2.0.1) Gecko Firefox/5.0.1'
-    family: 'Windows CE'
-    major:
+    family: 'Windows'
+    major: 'CE'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (WindowsCE 6.0; rv:2.0.1) Gecko/20100101 Firefox/4.0.1 SeaMonkey/2.1.1'
-    family: 'Windows CE'
-    major:
+    family: 'Windows'
+    major: 'CE'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (WindowsCE 6.0; rv:2.1.1) Gecko/ Firefox/5.0.1'
-    family: 'Windows CE'
-    major:
+    family: 'Windows'
+    major: 'CE'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (WindowsCE; rv:4.0) Gecko/20120320 Firefox/4.0'
-    family: 'Windows CE'
-    major:
+    family: 'Windows'
+    major: 'CE'
     minor:
     patch:
     patch_minor:
@@ -2378,36 +2378,36 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Box Sync/4.0.7848;Windows/8.1;x86 Family 6 Model 158 Stepping 9, GenuineIntel/32bit'
-    family: 'Windows 8.1'
-    major:
+    family: 'Windows'
+    major: '8.1'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Box Sync/4.0.7848;Windows/10;Intel64 Family 6 Model 158 Stepping 9, GenuineIntel/64bit'
-    family: 'Windows 10'
-    major:
+    family: 'Windows'
+    major: '10'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) BoxNotes/1.3.0 Chrome/56.0.2924.87 Electron/1.6.8 Safari/537.36'
-    family: 'Windows 8.1'
-    major:
+    family: 'Windows'
+    major: '8.1'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) BoxNotes/1.3.0 Chrome/56.0.2924.87 Electron/1.6.8 Safari/537.36'
-    family: 'Windows 10'
-    major:
+    family: 'Windows'
+    major: '10'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Box/1.2.93;Windows/10;Intel64 Family 6 Model 158 Stepping 9, GenuineIntel/64bit'
-    family: 'Windows 10'
-    major:
+    family: 'Windows'
+    major: '10'
     minor:
     patch:
     patch_minor:


### PR DESCRIPTION
Windows UA:s have been recognized with major version as part of the family.


This PR will fix #286 