### PR TITLE
Add default regex to detect iOS for unknown versions

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1122,6 +1122,9 @@ os_parsers:
   - regex: 'CFNetwork/8.* Darwin/(17)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '11'
+  - regex: 'CFNetwork/.* Darwin/'
+    os_replacement: 'iOS'
+
   # iOS Apps
   - regex: '\b(iOS[ /]|iOS; |iPhone(?:/| v|[ _]OS[/,]|; | OS : |\d,\d/|\d,\d; )|iPad/)(\d{1,2})[_\.](\d{1,2})(?:[_\.](\d+))?'
     os_replacement: 'iOS'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2474,3 +2474,10 @@ test_cases:
     minor: '2'
     patch:
     patch_minor:
+
+  - user_agent_string: 'MyApp/1.0 CFNetwork/9999.99 Darwin/99.99.99'
+    family: 'iOS'
+    major:
+    minor:
+    patch:
+    patch_minor:


### PR DESCRIPTION
This commit adds a default regex for iOS detection even if the specific OS version isn't known (useful for future versions that weren't released yet)