### PR TITLE
Add support for CFNetwork macOS Apps on macOS v. 10.13

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1055,6 +1055,10 @@ os_parsers:
   # CFNetwork macOS Apps (must be before CFNetwork iOS Apps
   # @ref: https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
   ##########
+  - regex: 'CFNetwork/.* Darwin/17\.\d+.*\(x86_64\)'
+    os_replacement: 'Mac OS X'
+    os_v1_replacement: '10'
+    os_v2_replacement: '13'
   - regex: 'CFNetwork/.* Darwin/16\.\d+.*\(x86_64\)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2474,3 +2474,10 @@ test_cases:
     minor: '2'
     patch:
     patch_minor:
+
+  - user_agent_string: 'MyApp/1.0 CFNetwork/893.13.1 Darwin/17.3.0 (x86_64)'
+    family: 'Mac OS X'
+    major: '10'
+    minor: '13'
+    patch:
+    patch_minor:


### PR DESCRIPTION
Add support for CFNetwork macOS Apps on macOS v. 10.13