### PR TITLE
Added support for Outlook >= 2.62.0 running on iOS

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -589,6 +589,11 @@ user_agent_parsers:
   - regex: '(iPod|iPhone|iPad)'
     family_replacement: 'Mobile Safari UI/WKWebView'
 
+  ##########################
+  # Outlook on iOS >= 2.62.0
+  ##########################
+  - regex: '(Outlook-iOS)/\d+\.\d+\.prod\.iphone \((\d+)\.(\d+)\.(\d+)\)'
+
   - regex: '(AvantGo) (\d+).(\d+)'
 
   - regex: '(OneBrowser)/(\d+).(\d+)'
@@ -1137,6 +1142,11 @@ os_parsers:
   - regex: '\b(iOS[ /]|iOS; |iPhone(?:/| v|[ _]OS[/,]|; | OS : |\d,\d/|\d,\d; )|iPad/)(\d{1,2})[_\.](\d{1,2})(?:[_\.](\d+))?'
     os_replacement: 'iOS'
   - regex: '\((iOS);'
+
+  ##########################
+  # Outlook on iOS >= 2.62.0
+  ##########################
+  - regex: 'Outlook-(iOS)/\d+\.\d+\.prod\.iphone'
 
   ##########
   # Apple TV
@@ -4679,6 +4689,14 @@ device_parsers:
     device_replacement: 'iOS-Device'
     brand_replacement: 'Apple'
     model_replacement: 'iOS-Device'
+
+  ##########################
+  # Outlook on iOS >= 2.62.0
+  ##########################
+  - regex: 'Outlook-(iOS)/\d+\.\d+\.prod\.iphone'
+    brand_replacement: 'Apple'
+    device_replacement: 'iPhone'
+    model_replacement: 'iPhone'
 
   ##########
   # Acer

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -80014,3 +80014,8 @@ test_cases:
     family: 'Generic Smartphone'
     brand: 'Generic'
     model: 'Smartphone'
+
+  - user_agent_string: 'Outlook-iOS/665.29827.prod.iphone (2.63.0)'
+    family: 'iPhone'
+    brand: 'Apple'
+    model: 'iPhone'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2482,3 +2482,10 @@ test_cases:
     minor: '13'
     patch:
     patch_minor:
+
+  - user_agent_string: 'Outlook-iOS/665.29827.prod.iphone (2.63.0)'
+    family: 'iOS'
+    major:
+    minor:
+    patch:
+    patch_minor:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7383,3 +7383,9 @@ test_cases:
     major: '1'
     minor: '2'
     patch:
+
+  - user_agent_string: 'Outlook-iOS/665.29827.prod.iphone (2.63.0)'
+    family: 'Outlook-iOS'
+    major: '2'
+    minor: '63'
+    patch: '0'


### PR DESCRIPTION
We have users who have updated to more recent versions of Outlook on iOS and it appears the developers opted to change the UA string. Re-opening this as shuffling my fork around caused the original to close out.