### PR TITLE
Should account for Trident/8.0 as IE11 in the UA

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -679,7 +679,7 @@ user_agent_parsers:
   - regex: '(Phantom)/V(\d+)\.(\d+)'
     family_replacement: 'Phantom Browser'
  
-  - regex: '(Trident)/(7)\.(0)'
+  - regex: '(Trident)/(7|8)\.(0)'
     family_replacement: 'IE'
     v1_replacement: '11'
 

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7383,3 +7383,9 @@ test_cases:
     major: '1'
     minor: '2'
     patch:
+
+  - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/8.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)'
+    family: 'IE'
+    major: '11'
+    minor: '0'
+    patch:


### PR DESCRIPTION
Trident/8.0 (Compatibility view of Win10 with Internet Explorer 11) exists as a possible UA version for IE11 - it should be accounted for.