### PR TITLE
Replace empty alternations by optional group

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -2489,7 +2489,7 @@ device_parsers:
     device_replacement: '$1 $2'
     brand_replacement: 'iBall'
     model_replacement: '$1 $2'
-  - regex: '; *(IBall)(?:[ _]([^;/]+)|) Build'
+  - regex: '; *(IBall)(?:[ _]([^;/]+))? Build'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'iBall'
@@ -4848,7 +4848,7 @@ device_parsers:
   ##########
   # LGE NetCast TV
   ##########
-  - regex: 'LGE; (?:Media\/)?([^;]*);[^;]*;[^;]*;?\); "?LG NetCast(\.TV|\.Media|)-\d+'
+  - regex: 'LGE; (?:Media\/)?([^;]*);[^;]*;[^;]*;?\); "?LG NetCast(\.TV|\.Media)?-\d+'
     device_replacement: 'NetCast$2'
     brand_replacement: 'LG'
     model_replacement: '$1'


### PR DESCRIPTION
A popular regexp implementation of Rust does not allow empty
alternations (not blaming).

I replaced the empty alternation `(?:...|)` by `(?:..)?` which is equivalent?

I am working on a Rust ua-parser. In order to get all tests passing the cleanest solution would be to replace the pattern.