### PR TITLE
Fix test_device.yaml and test_os.yaml indentation

### DIFF
--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -80030,7 +80030,7 @@ test_cases:
     brand: 'Apple'
     model: 'iPhone9,3'
  
-    - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 Flipboard/4.2.2'
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 Flipboard/4.2.2'
     family: 'iPhone'
     brand: 'Apple'
     model: 'iPhone'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2504,7 +2504,7 @@ test_cases:
     patch: '5'
     patch_minor:
  
-   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 Flipboard/4.2.2'
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 Flipboard/4.2.2'
     family: 'iOS'
     major: '11'
     minor: '2'


### PR DESCRIPTION
It's inconsistent and yaml-cpp doesn't like it.