### PR TITLE
Added OS and UserAgent parser for Salesforce UA on Android

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -41,6 +41,9 @@ user_agent_parsers:
   - regex: '(Tableau)/(\d+)\.(\d+)'
     family_replacement: 'Tableau'
 
+  # Salesforce
+  - regex: '(Salesforce)(?:.)\/(\d+)\.(\d?)'
+
   #StatusCake
   - regex: '(\(StatusCake\))'
     family_replacement: 'StatusCakeBot'
@@ -865,6 +868,10 @@ os_parsers:
     os_replacement: 'Windows Phone'
   # JUC
   - regex: '^(JUC).*; ?U; ?(?:Android)?(\d+)\.(\d+)(?:[\.\-]([a-z0-9]+))?'
+    os_replacement: 'Android'
+
+  # Salesforce
+  - regex: '(android)\s(?:mobile\/)(\d+)\.(\d+)\.?(\d+)?'
     os_replacement: 'Android'
 
   ##########

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2553,3 +2553,17 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'SalesforceMobileSDK/5.3.0 android mobile/8.0.0 (SM-G955F) Salesforce1/15.2 Native uid_c4589f605fad8c7e ftr_ Cordova/6.2.3'
+    family: 'Android'
+    major: '8'
+    minor: '0'
+    patch: '0'
+    patch_minor: 
+
+  - user_agent_string: 'SalesforceMobileSDK/5.3.0 android mobile/7.0 (SM-G955U) Salesforce1/15.2 Native uid_4ec4068eddf27447 ftr_ Cordova/6.2.3'
+    family: 'Android'
+    major: '7'
+    minor: '0'
+    patch: 
+    patch_minor: 
+

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7619,3 +7619,9 @@ test_cases:
     minor: '19'
     patch: '0'
 
+  - user_agent_string: 'SalesforceMobileSDK/5.3.0 android mobile/7.1.1 (XT1635-02) Salesforce1/15.2 Native uid_bef1747905d064c6 ftr_ Cordova/6.2.3'
+    family: 'Salesforce'
+    major: '15'
+    minor: '2'
+    patch: 
+


### PR DESCRIPTION
Added to regexes.yaml: parsers to grab lowercase `android` portion of Salesforce UA and Salesforce browser version. 