### PR TITLE
Update Android Regex to allow for single digit OS versions

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -838,7 +838,7 @@ os_parsers:
   # Android
   # can actually detect rooted android os. do we care?
   ##########
-  - regex: '(Android)[ \-/](\d+)\.(\d+)(?:[.\-]([a-z0-9]+))?'
+  - regex: '(Android)[ \-/](\d+)\.?(\d+)?(?:[.\-]([a-z0-9]+))?'
 
   - regex: '(Android) Donut'
     os_v1_replacement: '1'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2567,3 +2567,10 @@ test_cases:
     patch: 
     patch_minor: 
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Pixel Build/PPP3.180510.008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.81 Mobile Safari/537.36'
+    family: 'Android'
+    major: '9'
+    minor:
+    patch: 
+    patch_minor: 
+


### PR DESCRIPTION
The current Android 9 user agent is as follows
Mozilla/5.0 (Linux; Android 9; Pixel Build/PPP3.180510.008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.81 Mobile Safari/537.36
This commit allows the code to parse 9 as a valid OS version.