### PR TITLE
Support WebView detection in Android KitKat to Lollipop

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -309,6 +309,8 @@ user_agent_parsers:
   - regex: '(Crosswalk)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
 
   # Chrome Mobile
+  - regex: 'Version/.+(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Chrome Mobile WebView'
   - regex: '; wv\).+(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile WebView'
   - regex: '(CrMo)/(\d+)\.(\d+)\.(\d+)\.(\d+)'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2552,14 +2552,14 @@ test_cases:
     minor:
     patch:
     patch_minor:
- 
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; LG-TP260 Build/NRD90U; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36 Instagram 33.0.0.11.92 Android (24/7.0; 320dpi; 720x1193; LGE/lge; LG-TP260; lv517; lv517; en_US; 93117667)'
     family: 'Android'
     major: '7'
     minor: '0'
     patch:
     patch_minor:
-    
+
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 Instagram 33.0.0.11.96 (iPhone9,3; iOS 11_2_5; en_AU; en-AU; scale=2.00; gamut=wide; 750x1334)'
     family: 'iOS'
     major: '11'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -216,6 +216,13 @@ test_cases:
     minor: '0'
     patch: '3029'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.4.4; SHV31 Build/S2280) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36'
+    family: 'Chrome Mobile WebView'
+    major: '33'
+    minor: '0'
+    patch: '0'
+    patch_minor: '0'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.2; Galaxy Nexus Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
     family: 'Chrome Mobile'
     major: '18'
@@ -6844,7 +6851,7 @@ test_cases:
     patch: '1084'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.4.4; de-de; SM-G850F Build/KTU84P) AppleWebKit/537.16 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.16 Chrome/33.0.0.0'
-    family: 'Chrome Mobile'
+    family: 'Chrome Mobile WebView'
     major: '33'
     minor: '0'
     patch: '0'


### PR DESCRIPTION
As described at https://github.com/ua-parser/uap-core/issues/38#issuecomment-357320488 , add WebView detection based on the presence of the `Version/_X.X_` string.