### PR TITLE
Fix to identify MI devices

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -4288,7 +4288,7 @@ device_parsers:
   # XiaoMi
   # @ref: http://www.xiaomi.com/event/buyphone
   #########
-  - regex: '; *((MI|HM|MI-ONE|Redmi)[ -](NOTE |Note )?[^;/]*) (Build|MIUI)/'
+  - regex: '; *((Mi|MI|HM|MI-ONE|Redmi)[ -](NOTE |Note )?[^;/]*) (Build|MIUI)/'
     device_replacement: 'XiaoMi $1'
     brand_replacement: 'XiaoMi'
     model_replacement: '$1'


### PR DESCRIPTION
Dalvik/2.1.0 (Linux; U; Android 8.0.0; Mi A1 MIUI/V9.5.13.0.ODHMIFA)
Dalvik/2.1.0 (Linux; U; Android 5.0.2; Mi 4i MIUI/V8.1.7.0.LXIMIDI)