### PR TITLE
Fix indenting in regexes.yaml

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -29,7 +29,7 @@ user_agent_parsers:
   # Pingdom
   - regex: '(Pingdom.com_bot_version_)(\d+)\.(\d+)'
     family_replacement: 'PingdomBot'
-    # 'Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34'
+  # 'Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34'
   - regex: '(PingdomTMS)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'PingdomBot'
 


### PR DESCRIPTION
The additional spaces may cause IDEs (specifically IntelliJ in my case) to transform this into a tab character. As a result of this, Java can not properly parse the YAML file, and every look up throws the following exception `org.yaml.snakeyaml.scanner.ScannerException`.

By placing the comment on the expected level, parsing works as intended