### PR TITLE
regex for android 9 (and Pixel 2 XL)

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -844,7 +844,7 @@ os_parsers:
   # Android
   # can actually detect rooted android os. do we care?
   ##########
-  - regex: '(Android)[ \-/](\d+)\.(\d+)(?:[.\-]([a-z0-9]+))?'
+  - regex: '(Android)[ \-/](\d+)(?:\.(\d+))?(?:[.\-]([a-z0-9]+))?'
 
   - regex: '(Android) Donut'
     os_v1_replacement: '1'
@@ -2300,7 +2300,7 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'Google'
     model_replacement: '$1'
-  - regex: '; *(Pixel \w+) Build'
+  - regex: '; *(Pixel [\w\ ]+) Build'
     device_replacement: '$1'
     brand_replacement: 'Google'
     model_replacement: '$1'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -79960,6 +79960,11 @@ test_cases:
     brand: 'Google'
     model: 'Pixel C'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36'
+    family: 'Pixel 2 XL'
+    brand: 'Google'
+    model: 'Pixel 2 XL'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0; RCT6773W22B Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85'
     family: 'RCT6773W22B'
     brand: 'RCA'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -119,6 +119,20 @@ test_cases:
     patch: '2'
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36'
+    family: 'Android'
+    major: '9'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9.1.2; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36'
+    family: 'Android'
+    major: '9'
+    minor: '1'
+    patch: '2'
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500/S8500XXJEE; U; Bada/1.0; nl-nl) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B'
     family: 'Bada'
     major: '1'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -210,6 +210,12 @@ test_cases:
     minor: '0'
     patch: '660'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36'
+    family: 'Chrome Mobile WebView'
+    major: '68'
+    minor: '0'
+    patch: '3440'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.1.2; Nexus 5X Build/N2G47W; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36'
     family: 'Chrome Mobile WebView'
     major: '58'


### PR DESCRIPTION
Adds detection of Android 9 UAs. Previously Android version was detected as 0.0.0 because regex could not handle version numbers without a sub version. 

Sample user agent string:
Mozilla/5.0 (Linux; Android 9; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36

Pixel devices with a space in the name (like "Pixel 2 XL") are now also detected.