### PR TITLE
Add parser for Citrix Chrome app on Chrome OS

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -886,6 +886,14 @@ os_parsers:
   - regex: '(Silk-Accelerated=[a-z]{4,5})'
     os_replacement: 'Android'
 
+  # Citrix Chrome App on Chrome OS
+  # Note, this needs to come before the windows parsers as the app doesn't
+  # properly identify as Chrome OS
+  #
+  # ex: Mozilla/5.0 (X11; Windows aarch64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp
+  - regex: '(x86_64|aarch64)\\ (\\d+)+\\.(\\d+)+\\.(\\d+)+.*Chrome.*(?:CitrixChromeApp)$'
+    os_replacement: 'Chrome OS'
+
   ##########
   # Windows
   # http://en.wikipedia.org/wiki/Windows_NT#Releases

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2630,3 +2630,24 @@ test_cases:
     patch: 
     patch_minor: 
 
+  - user_agent_string: 'Mozilla/5.0 (X11; Windows aarch64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp'
+    family: 'Chrome OS'
+    major: '10718'
+    minor: '88'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Windows x86_64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp'
+    family: 'Chrome OS',
+    major: '10718'
+    minor: '88'
+    patch: '2'
+    patch_minor:
+
+ - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 CitrixChromeApp'
+   family: 'Windows'
+   major: '10'
+   minor:
+   patch:
+   patch_minor:
+


### PR DESCRIPTION
Mozilla/5.0 (X11; Windows aarch64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp

The Citrix Chrome app doesn't identify itself correctly on Chrome OS devices and instead claims to be Windows. The app does properly identify information specific to these Chrome OS devices, such as aarch64 and x86_64 and includes the chrome os version.