### PR TITLE
Add parser for Citrix Chrome app on Chrome OS

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -891,7 +891,7 @@ os_parsers:
   # properly identify as Chrome OS
   #
   # ex: Mozilla/5.0 (X11; Windows aarch64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp
-  - regex: '(x86_64|aarch64)\\ (\\d+)+\\.(\\d+)+\\.(\\d+)+.*Chrome.*(?:CitrixChromeApp)$'
+  - regex: '(x86_64|aarch64)\ (\d+)+\.(\d+)+\.(\d+)+.*Chrome.*(?:CitrixChromeApp)$'
     os_replacement: 'Chrome OS'
 
   ##########

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -886,6 +886,14 @@ os_parsers:
   - regex: '(Silk-Accelerated=[a-z]{4,5})'
     os_replacement: 'Android'
 
+  # Citrix Chrome App on Chrome OS
+  # Note, this needs to come before the windows parsers as the app doesn't
+  # properly identify as Chrome OS
+  #
+  # ex: Mozilla/5.0 (X11; Windows aarch64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp
+  - regex: '(x86_64|aarch64)\\ (\\d+)+\\.(\\d+)+\\.(\\d+)+.*Chrome.*(?:CitrixChromeApp)$'
+    os_replacement: 'Chrome OS'
+
   ##########
   # Windows
   # http://en.wikipedia.org/wiki/Windows_NT#Releases

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2638,16 +2638,16 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (X11; Windows x86_64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp'
-    family: 'Chrome OS',
+    family: 'Chrome OS'
     major: '10718'
     minor: '88'
     patch: '2'
     patch_minor:
 
- - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 CitrixChromeApp'
-   family: 'Windows'
-   major: '10'
-   minor:
-   patch:
-   patch_minor:
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 CitrixChromeApp'
+    family: 'Windows'
+    major: '10'
+    minor:
+    patch:
+    patch_minor:
 

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2630,3 +2630,24 @@ test_cases:
     patch: 
     patch_minor: 
 
+  - user_agent_string: 'Mozilla/5.0 (X11; Windows aarch64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp'
+    family: 'Chrome OS'
+    major: '10718'
+    minor: '88'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Windows x86_64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp'
+    family: 'Chrome OS',
+    major: '10718'
+    minor: '88'
+    patch: '2'
+    patch_minor:
+
+ - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 CitrixChromeApp'
+   family: 'Windows'
+   major: '10'
+   minor:
+   patch:
+   patch_minor:
+


### PR DESCRIPTION
The Citrix chrome app does not properly identify Chrome OS devices, and instead looks like Windows. 

Mozilla/5.0 (X11; Windows aarch64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp

The useragent does include the Chrome OS Version and aarch64/x86_64 for chrome os devices and not actual Windows devices, so this can be used to differentiate between the two.

Example user agent on an actual Windows device:
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 CitrixChromeApp