### PR TITLE
Handle useragents that present Windows 10

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -946,6 +946,10 @@ os_parsers:
     os_replacement: 'Windows'
     os_v1_replacement: '10'
 
+  - regex: '(Windows 10)'
+    os_replacement: 'Windows'
+    os_v1_replacement: '10'
+
   - regex: '(Windows NT 5\.0)'
     os_replacement: 'Windows'
     os_v1_replacement: '2000'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -777,6 +777,13 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'PAN GlobalProtect/4.1.2-11 (Microsoft Windows 10 Pro , 64-bit)'
+    family: 'Windows'
+    major: '10'
+    minor:
+    patch:
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'
     family: 'Windows'
     major: '8.1'


### PR DESCRIPTION
Example from Global Protect
`PAN GlobalProtect/4.1.2-11 (Microsoft Windows 10 Pro , 64-bit)`
