### PR TITLE
Detect ViaFree app

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1271,7 +1271,7 @@ os_parsers:
   ##########
   # Apple TV
   ##########
-  - regex: '(tvOS)(?:/| )(\d+).(\d+)(?:\.(\d+)|)'
+  - regex: '(tvOS)[/ ](\d+)\.(\d+)(?:\.(\d+)|)'
     os_replacement: 'tvOS'
 
   ##########

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -784,6 +784,10 @@ user_agent_parsers:
   # Box Drive and Box Sync https://www.box.com/resources/downloads
   - regex: '^(Box(?: Sync)?)/(\d+)\.(\d+)\.(\d+)'
 
+  # ViaFree streaming app https://www.viafree.{dk|se|no}
+  - regex: '^(ViaFree|Viafree)-(?:tvOS-)?[A-Z]{2}/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'ViaFree'
+
 os_parsers:
   ##########
   # HbbTV vendors

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1271,7 +1271,7 @@ os_parsers:
   ##########
   # Apple TV
   ##########
-  - regex: '(tvOS)(?:/| )(\d+).(\d+)(?:\.(\d+))?'
+  - regex: '(tvOS)(?:/| )(\d+).(\d+)(?:\.(\d+)|)'
     os_replacement: 'tvOS'
 
   ##########

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1271,7 +1271,7 @@ os_parsers:
   ##########
   # Apple TV
   ##########
-  - regex: '(tvOS)/(\d+).(\d+)'
+  - regex: '(tvOS)(?:/| )(\d+).(\d+)(?:\.(\d+))?'
     os_replacement: 'tvOS'
 
   ##########

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2679,3 +2679,16 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'ViaFree-DK/3.8.3 (com.MTGx.ViaFree.dk; build:7383; iOS 12.1.0) Alamofire/4.7.0'
+    family: 'iOS'
+    major: '12'
+    minor: '1'
+    patch: '0'
+    patch_minor:
+
+  - user_agent_string: 'Viafree-tvOS-DK/3.7.1 (com.MTGx.ViaFree.dk; build:7341; tvOS 12.1.0) Alamofire/4.7.0'
+    family: 'tvOS'
+    major: '12'
+    minor: '1'
+    patch: '0'
+    patch_minor:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7724,3 +7724,14 @@ test_cases:
     minor: '0'
     patch: '169645775'
 
+  - user_agent_string: 'ViaFree-DK/3.8.3 (com.MTGx.ViaFree.dk; build:7383; iOS 12.1.0) Alamofire/4.7.0'
+    family: 'ViaFree'
+    major: '3'
+    minor: '8'
+    patch: '3'
+
+  - user_agent_string: 'Viafree-tvOS-DK/3.7.1 (com.MTGx.ViaFree.dk; build:7341; tvOS 12.1.0) Alamofire/4.7.0'
+    family: 'ViaFree'
+    major: '3'
+    minor: '7'
+    patch: '1'


### PR DESCRIPTION
- Added detection of the ViaFree app, a streaming app popular in Scandinavian countries.
- Extended tvOS regex to capture patch version level.