### PR TITLE
Parse iPhone, iPad, and iPod as iOS devices

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1273,6 +1273,12 @@ os_parsers:
   ##########################
   - regex: 'Outlook-(iOS)/\d+\.\d+\.prod\.iphone'
 
+  ##########################
+  # iOS devices, the same regex matches mobile safari webviews
+  ##########################
+  - regex: '(iPod|iPhone|iPad)'
+    os_replacement: 'iOS'
+
   ##########
   # Apple TV
   ##########

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2419,6 +2419,13 @@ test_cases:
     patch: '4'
     patch_minor:
 
+  - user_agent_string: 'Zendesk for iPhone 1.2.1 (4395)'
+    family: 'iOS'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0+(Macintosh;+Intel+Mac+OS+X+10_11_6)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/52.0.2743.116+Safari/537.36'
     family: 'Mac OS X'
     major: '10'


### PR DESCRIPTION
There is already a parser that uses this same regex for detecting
Mobile Safari Webviews, which we should also identify as iOS devices.