### PR TITLE
Add Ghost User-Agent

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -410,6 +410,10 @@ user_agent_parsers:
   - regex: '(Whale)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Whale'
 
+  # Ghost
+  # @ref: http://www.ghost.org
+  - regex: '(Ghost)/(\d+)\.(\d+)\.(\d+)'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -1801,7 +1801,7 @@ test_cases:
     family: 'WebPageTest.org bot'
     major: '1'
     minor: '0'
-    patch: 
+    patch:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.0 Safari/537.36 PTST/1.0'
     family: 'WebPageTest.org bot'
@@ -7534,7 +7534,7 @@ test_cases:
     major: '33'
     minor: '0'
     patch: '0'
-    
+
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 Instagram 33.0.0.11.96 (iPhone9,3; iOS 11_2_5; en_AU; en-AU; scale=2.00; gamut=wide; 750x1334)'
     family: 'Instagram'
     major: '33'
@@ -7546,26 +7546,26 @@ test_cases:
     major: '4'
     minor: '2'
     patch: '2'
-    
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; SM-G610F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36 Flipboard/4.1.9/4323,4.1.9.4323'
     family: 'Flipboard'
     major: '4'
     minor: '1'
     patch: '9'
-    
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; SM-G930F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36 Onefootball/Android/9.10.6'
     family: 'Onefootball'
     major: '9'
     minor: '10'
     patch: '6'
-    
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; SM-A520F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 Flipboard-Briefing/2.7.28'
     family: 'Flipboard-Briefing'
     major: '2'
     minor: '7'
     patch: '28'
-    
-    
+
+
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/8.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)'
     family: 'IE'
     major: '11'
@@ -7596,7 +7596,7 @@ test_cases:
     major: '4'
     minor: '0'
     patch:
-      
+
   - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.2.2 Waterfox/55.2.2'
     family: 'Waterfox'
     major: '55'
@@ -7751,7 +7751,7 @@ test_cases:
     family: 'Salesforce'
     major: '15'
     minor: '2'
-    patch: 
+    patch:
 
   - user_agent_string: 'YahooMailProxy; https://help.yahoo.com/kb/yahoo-mail-proxy-SLN28749.html'
     family: 'YahooMailProxy'
@@ -7814,3 +7814,15 @@ test_cases:
     major:
     minor:
     patch:
+
+  - user_agent_string: 'Ghost/2.13.1+moya (https://github.com/TryGhost/Ghost)'
+    family: 'Ghost'
+    major: '2'
+    minor: '13'
+    patch: '1'
+
+  - user_agent_string: 'Ghost/2.10.8 (https://github.com/TryGhost/Ghost)'
+    family: 'Ghost'
+    major: '2'
+    minor: '10'
+    patch: '8'


### PR DESCRIPTION
This PR closes #378 and allows for parsing / detection of the User-Agent used by Ghost to make webhook calls to services.

Any feedback welcome!

Tim. 