### PR TITLE
Handling of cases where PTST doesn't have minor version

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -34,7 +34,7 @@ user_agent_parsers:
     family_replacement: 'PingdomBot'
 
   # PTST / WebPageTest.org crawlers
-  - regex: ' (PTST)/(\d+)\.(\d+)$'
+  - regex: ' (PTST)/(\d+)(?:\.(\d+)|)$'
     family_replacement: 'WebPageTest.org bot'
 
   # Datanyze.com spider
@@ -1488,7 +1488,7 @@ device_parsers:
     model_replacement: 'Feature Phone'
 
   # PTST / WebPageTest.org crawlers
-  - regex: ' PTST/\d+\.\d+$'
+  - regex: ' PTST/\d+(?:\.|)\d+$'
     device_replacement: 'Spider'
     brand_replacement: 'Spider'
 

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1488,7 +1488,7 @@ device_parsers:
     model_replacement: 'Feature Phone'
 
   # PTST / WebPageTest.org crawlers
-  - regex: ' PTST/\d+(?:\.|)\d+$'
+  - regex: ' PTST/\d+(?:\.)?\d+$'
     device_replacement: 'Spider'
     brand_replacement: 'Spider'
 

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -665,6 +665,11 @@ test_cases:
     brand: 'Spider'
     model:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.81 Mobile Safari/537.36 PTST/391'
+    family: 'Spider'
+    brand: 'Spider'
+    model:
+
   - user_agent_string: 'Mozilla/5.0 (X11; Datanyze; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
     family: 'Spider'
     brand: 'Spider'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -1815,6 +1815,12 @@ test_cases:
     minor: '140508'
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.81 Mobile Safari/537.36 PTST/391'
+    family: 'WebPageTest.org bot'
+    major: '391'
+    minor:
+    patch:
+
   - user_agent_string: 'Mozilla/5.0 (X11; Datanyze; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
     family: 'Datanyze'
     major:


### PR DESCRIPTION
Fix for cases where user agent contains PTST string but doesn't contain minor version. e.g. PTST/391

E.g. `Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.81 Mobile Safari/537.36 PTST/391` wasn't detected as PTST/WebPageTest.org crawler.