### PR TITLE
Add regex for Xiaomi MIX, MIX 2 and MIX 2S. And regex for Samsung device with chrome

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -3815,6 +3815,10 @@ device_parsers:
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
+  - regex: '; *((?:SCH|SGH|SHV|SHW|SPH|SC|SM)\-[A-Za-z0-9]{5})[\)]'
+    device_replacement: 'Samsung $1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
 
   #########
   # Sharp

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -4395,6 +4395,14 @@ device_parsers:
     device_replacement: 'XiaoMi $1'
     brand_replacement: 'XiaoMi'
     model_replacement: '$1'
+  - regex: '; *(MIX) (Build|MIUI)/'
+    device_replacement: 'XiaoMi $1'
+    brand_replacement: 'XiaoMi'
+    model_replacement: '$1'
+  - regex: '; *((MIX) ([^;/]*)) (Build|MIUI)/'
+    device_replacement: 'XiaoMi $1'
+    brand_replacement: 'XiaoMi'
+    model_replacement: '$1'
 
   #########
   # Xolo

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -58070,6 +58070,16 @@ test_cases:
     brand: 'Samsung'
     model: 'GT-S8600-ORANGE'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; SM-G9500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36'
+    family: 'Samsung SM-G9500'
+    brand: 'Samsung'
+    model: 'SM-G9500'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G9500 Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.3 Chrome/67.0.3396.87 Mobile Safari/537.36'
+    family: 'Samsung SM-G9500'
+    brand: 'Samsung'
+    model: 'SM-G9500'
+
   - user_agent_string: 'UCWEB/2.0 (Symbian; U; S60 V5; Pt-BR; SamsungI8910) U2/1.0.0 UCBrowser/8.9.0.277 U2/1.0.0 Mobile'
     family: 'Samsung I8910'
     brand: 'Samsung'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -77450,6 +77450,21 @@ test_cases:
     brand: 'XiaoMi'
     model: 'Redmi Note 2'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; MIX Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.1.1'
+    family: 'XiaoMi MIX'
+    brand: 'XiaoMi'
+    model: 'MIX'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 9; MIX 2S Build/PKQ1.180729.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.7.3'
+    family: 'XiaoMi MIX 2S'
+    brand: 'XiaoMi'
+    model: 'MIX 2S'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; MIX 2 Build/OPR1.170623.027) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.1.1'
+    family: 'XiaoMi MIX 2'
+    brand: 'XiaoMi'
+    model: 'MIX 2'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.1.1; XOLO A1000 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
     family: 'Xolo A1000'
     brand: 'Xolo'


### PR DESCRIPTION
UA sample for Xiaomi MIX 2S, MIX and MIX 2:
Mozilla/5.0 (Linux; U; Android 9; MIX 2S Build/PKQ1.180729.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.7.3
Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; MIX Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.1.1
Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; MIX 2 Build/OPR1.170623.027) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.1.1

Previously, these UAs are parsed as "Generic Smartphone". And now they are parsed correctly as Xiaomi MIX.

Source:
http://www.fynas.com/ua/search?d=&b=MIUI%E6%B5%8F%E8%A7%88%E5%99%A8&k=MIX&page=1