### PR TITLE
Fix snapchat version regex

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -145,7 +145,7 @@ user_agent_parsers:
   # Onefootball app
   - regex: 'Mozilla.*Mobile.*(Onefootball)\/Android.(\d+)\.(\d+)\.(\d+)'
   # Snapchat
-  - regex: '(Snapchat)\/(\d+)\.(\d+)\.(\d+).(\d+)'
+  - regex: '(Snapchat)\/(\d+)\.(\d+)\.(\d+)\.(\d+)'
 
   # Basilisk
   - regex: '(Firefox)/(\d+)\.(\d+) Basilisk/(\d+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7870,3 +7870,9 @@ test_cases:
     minor: '0'
     patch: '131'
     patch_minor: '0'
+
+  - user_agent_string: 'Snapchat/10.29.1.0 (iPhone10,1; iOS 11.2; gzip)'
+    family: 'Snapchat'
+    major: '10'
+    minor: '29'
+    patch: '1'


### PR DESCRIPTION
Fix the numbers for SnapChat version. It seems that versions have 4 numbers separated by dots.

Example: [Snapchat/10.29.1.0 (iPhone10,1; iOS 11.2; gzip)](https://user-agents.net/string/snapchat-10-29-1-0-iphone10-1-ios-11-2-gzip)


```
$ npm test

> uap-core@0.6.7 test /git/github/uap-core
> mocha --opts ./tests/mocha.opts ./tests


  31868 passing (11s)
```

Added previously with  #346 ?