### PR TITLE
remove prepended 'User agent:' from User-Agent in test_ua.yaml

### DIFF
--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -756,7 +756,7 @@ test_cases:
     minor: '53'
     patch:
 
-  - user_agent_string: 'User agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.20 Safari/537.36 OPR/15.0.1147.18 (Edition Next)'
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.20 Safari/537.36 OPR/15.0.1147.18 (Edition Next)'
     family: 'Opera'
     major: '15'
     minor: '0'


### PR DESCRIPTION
According to the https://github.com/ua-parser/uap-core/blame/2e6c983e42e7aae7d957a263cb4d3de7ccbd92af/tests/test_ua.yaml#L759 for about 6 years there has been a typo from https://github.com/ua-parser/uap-core/commit/09ea9411da00cbaec25e513f4dd73c4c13936529

This PR removes the prepended `User agent:` on the User-Agent string.