### PR TITLE
Treat tab character in tests/test_ua.yaml

### DIFF
--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -1,5 +1,5 @@
 test_cases:
-	
+
   - user_agent_string: 'atc/1.0 watchOS/5.1.3 model/Watch3,4 hwp/t8004 build/16S535 (6; dt:156)'
     family: 'Apple Watch App'
     major: '3'


### PR DESCRIPTION
Treat tab character in YAML file because it causes error at some parser (e.g. snakeyaml).

Generally, [YAML forbid tab character](https://yaml.org/faq.html).