### PR TITLE
bump version number to 0.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uap-core",
   "description": "The regex file necessary to build language ports of Browserscope's user agent parser.",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "maintainers": [
     {
       "name": "Tobie Langel",


### PR DESCRIPTION
I attempted to update uap-go to v0.6.8 of uap-core and discovered that an errant tab broke the go tests.  I fixed this locally, and then discovered this was already fixed in uap-core in 77824582d8d38dfa57481873e0ccae80f0deab3b.  So bumping the version number so we can have a clear release to merge back into uap-go (to solve https://github.com/ua-parser/uap-go/issues/62)