### PR TITLE
Fix Ruby "duplicated range" warnings for `A-z` classes

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -3399,7 +3399,7 @@ device_parsers:
   # Nextbook
   # @ref: http://nextbookusa.com
   #########
-  - regex: '; *(NXM\d+[A-z0-9_]*|Next\d[A-z0-9_ \-]*|NEXT\d[A-z0-9_ \-]*|Nextbook [A-z0-9_ ]*|DATAM803HC|M805)(?: Build|[\);])'
+  - regex: '; *(NXM\d+[A-Za-z0-9_]*|Next\d[A-Za-z0-9_ \-]*|NEXT\d[A-Za-z0-9_ \-]*|Nextbook [A-Za-z0-9_ ]*|DATAM803HC|M805)(?: Build|[\);])'
     device_replacement: '$1'
     brand_replacement: 'Nextbook'
     model_replacement: '$1'
@@ -4764,7 +4764,7 @@ device_parsers:
   # NOKIA
   # @note: NokiaN8-00 comes before iphone. Sometimes spoofs iphone
   ##########
-  - regex: 'Nokia(N[0-9]+)([A-z_\-][A-z0-9_\-]*)'
+  - regex: 'Nokia(N[0-9]+)([A-Za-z_\-][A-Za-z0-9_\-]*)'
     device_replacement: 'Nokia $1'
     brand_replacement: 'Nokia'
     model_replacement: '$1$2'


### PR DESCRIPTION
Ruby flags a couple of regexes as having redundant class characters:

```
.gem/ruby/2.3.7/gems/user_agent_parser-2.5.1/lib/user_agent_parser/parser.rb:97: warning: character class has duplicated range
.gem/ruby/2.3.7/gems/user_agent_parser-2.5.1/lib/user_agent_parser/parser.rb:48: warning: character class has duplicated range
```

This can get quite noisy when running many unit tests 😅

The source of the problem is that Ruby includes the `_` in the `[A-z]` class.  Using `[A-Za-z_]` is more explicit, and isn't flagged by Ruby's parser.