### PR TITLE
fix ua regex for Android >=9

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -586,7 +586,7 @@ user_agent_parsers:
   # Browser major_version.minor_version.beta_version (space instead of slash)
   - regex: '(iRider|Crazy Browser|SkipStone|iCab|Lunascape|Sleipnir|Maemo Browser) (\d+)\.(\d+)\.(\d+)'
   # Browser major_version.minor_version (space instead of slash)
-  - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris|Microsoft SkyDriveSync|The Bat!) (\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris|Microsoft SkyDriveSync|The Bat!) (\d+)(?:\.(\d+))?(?:\.(\d+)|)'
 
   # Kindle WebKit
   - regex: '(Kindle)/(\d+)\.(\d+)'

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -586,7 +586,7 @@ user_agent_parsers:
   # Browser major_version.minor_version.beta_version (space instead of slash)
   - regex: '(iRider|Crazy Browser|SkipStone|iCab|Lunascape|Sleipnir|Maemo Browser) (\d+)\.(\d+)\.(\d+)'
   # Browser major_version.minor_version (space instead of slash)
-  - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris|Microsoft SkyDriveSync|The Bat!) (\d+)(?:\.(\d+))?(?:\.(\d+)|)'
+  - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris|Microsoft SkyDriveSync|The Bat!) (\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
 
   # Kindle WebKit
   - regex: '(Kindle)/(\d+)\.(\d+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7943,4 +7943,9 @@ test_cases:
     major: '1'
     minor: '0'
     patch: '0'
-    
+
+  - user_agent_string: 'Android: Client/0.0.0-indev (Android SDK built for x86; Android 9)'
+    family: 'Android'
+    major: '9'
+    minor:
+    patch:


### PR DESCRIPTION
`UserAgentParser.Parse()` cannot properly parse Android versions 9 and beyond.
Cannot match str without subversion, so [minor, major, patch] contain none 

Example of UA:
"Android: Test-Client/0.0.0-indev (Android SDK built for x86; Android 9)"
result of parsing => `{'major': None, 'minor': None, 'patch': None}`
expected => `{'major': 9, 'minor': None, 'patch': None}`

 