### PR TITLE
Android 9 and 10

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -942,7 +942,8 @@ os_parsers:
   - regex: '(Android) Honeycomb'
     os_v1_replacement: '3'
 
-  - regex: '(Android).(\d+);'    
+  # Android 9; Android 10;
+  - regex: '(Android) (\d+);'    
 
   # UCWEB
   - regex: '^UCWEB.*; (Adr) (\d+)\.(\d+)(?:[.\-]([a-z0-9]+)|);'

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -942,6 +942,8 @@ os_parsers:
   - regex: '(Android) Honeycomb'
     os_v1_replacement: '3'
 
+  - regex: '(Android).(\d+);'    
+
   # UCWEB
   - regex: '^UCWEB.*; (Adr) (\d+)\.(\d+)(?:[.\-]([a-z0-9]+)|);'
     os_replacement: 'Android'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -139,6 +139,20 @@ test_cases:
     minor: '4'
     patch: '2'
     patch_minor:
+  
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; motorola one power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36'
+    family: 'Android'
+    major: '9'
+    minor: 
+    patch: 
+    patch_minor:
+  
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 10; SM-G970F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3396.81 Mobile Safari/537.36'
+    family: 'Android'
+    major: '10'
+    minor: 
+    patch: 
+    patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500/S8500XXJEE; U; Bada/1.0; nl-nl) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B'
     family: 'Bada'


### PR DESCRIPTION
stacked with the same issue: https://github.com/ua-parser/uap-python/issues/72
added regexp to fix it as your manual said