### PR TITLE
Ensure QQ Browser on Android is detected correctly as QQ Browser Mobile

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -350,6 +350,14 @@ user_agent_parsers:
   # Google Search App on Android, eg:
   - regex: 'Mozilla.+Android.+(GSA)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Google'
+    
+  # QQ Browsers
+  - regex: '(MQQBrowser/Mini)(?:(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+    family_replacement: 'QQ Browser Mini'
+  - regex: '(MQQBrowser)(?:/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+    family_replacement: 'QQ Browser Mobile'
+  - regex: '(QQBrowser)(?:/(\d+)(?:\.(\d+)\.(\d+)(?:\.(\d+)|)|)|)'
+    family_replacement: 'QQ Browser'
 
   # Chrome Mobile
   - regex: 'Version/.+(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
@@ -376,14 +384,6 @@ user_agent_parsers:
   # Sogou Explorer 2.X
   - regex: '(SE 2\.X) MetaSr (\d+)\.(\d+)'
     family_replacement: 'Sogou Explorer'
-
-  # QQ Browsers
-  - regex: '(MQQBrowser/Mini)(?:(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
-    family_replacement: 'QQ Browser Mini'
-  - regex: '(MQQBrowser)(?:/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
-    family_replacement: 'QQ Browser Mobile'
-  - regex: '(QQBrowser)(?:/(\d+)(?:\.(\d+)\.(\d+)(?:\.(\d+)|)|)|)'
-    family_replacement: 'QQ Browser'
 
   # Rackspace Monitoring
   - regex: '(Rackspace Monitoring)/(\d+)\.(\d+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7944,3 +7944,9 @@ test_cases:
     minor: '0'
     patch: '0'
     
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 9; zh-cn; vivo X21 Build/PKQ1.180819.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/9.9 Mobile Safari/537.36'
+    family: 'QQ Browser Mobile'
+    major: '9'
+    minor: '9'
+    patch:
+  


### PR DESCRIPTION
The current detection is causing issues for https://polyfill.io users who have customers using QQ Browser as it is identifying the browser incorrectly as Chrome Mobile whereas it is actually a fork of Chrome that has a different set of features than Chrome has.