### PR TITLE
Added case-insensitive flag for Instagram regex

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -138,6 +138,8 @@ user_agent_parsers:
   - regex: '(Pinterest)(?: for Android(?: Tablet|)|)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
   # Instagram app
   - regex: 'Mozilla.*Mobile.*(Instagram).(\d+)\.(\d+)\.(\d+)'
+    regex_flag: 'i'
+    family_replacement: 'Instagram'
   # Flipboard app
   - regex: 'Mozilla.*Mobile.*(Flipboard).(\d+)\.(\d+)\.(\d+)'
   # Flipboard-briefing app


### PR DESCRIPTION
I'm receiving lowercase Instagram useragents. I've added it to regexes.yaml, but test failing because tool doesn't count `regex_flag` property. Also, I didn't found `regex_flag` property in other UA useragents and I'm not sure that my changes is correct