### PR TITLE
Remove negative lookahead to help uap-go

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -5382,7 +5382,7 @@ device_parsers:
   - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]+?)(?: Build|\) AppleWebKit).+? Mobile Safari'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
-  - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]+?)(?: Build|\) AppleWebKit).+?(?<! Mobile) Safari'
+  - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]+?)(?: Build|\) AppleWebKit).+? Safari'
     brand_replacement: 'Generic_Android_Tablet'
     model_replacement: '$1'
   - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]+?)(?: Build|\))'


### PR DESCRIPTION
This PR removes the negative lookahead on the regex matching `'Generic_Android_Tablet'` which was introduced in https://github.com/ua-parser/uap-core/pull/449. 

Golang's `regexp` only supports RE2 syntax, and so uap-go panics when trying to parse the latest version (v0.7.0) of the regexes file. Interestingly, the relevant tests still seem to pass and match `'Generic_Android_Tablet'` over `'Generic_Android'`, I think because of the ordering of the regexes in that block (??)

A similar thing happened before in https://github.com/ua-parser/uap-core/pull/64 . 