### PR TITLE
add support for Macintosh device

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1807,7 +1807,6 @@ device_parsers:
     brand_replacement: 'Apanda'
     model_replacement: '$1'
 
-
   #########
   # Archos
   # @ref: http://www.archos.com/de/products/tablets.html

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1807,15 +1807,6 @@ device_parsers:
     brand_replacement: 'Apanda'
     model_replacement: '$1'
 
-  #########
-  # Apple
-  # @ref: https://www.apple.com/mac/
-  # @note: lookup Mac OS, but exclude iPad, Apple TV, a HTC phone, Kindle, LG
-  #########
-  - regex: '^(?=.*Mac OS)(?!.*(like Mac|HTC|Silk|LG)).*'
-    device_replacement: 'Mac'
-    brand_replacement: 'Apple'
-    model_replacement: 'Mac'
 
   #########
   # Archos
@@ -5481,3 +5472,14 @@ device_parsers:
     device_replacement: 'Generic Feature Phone'
     brand_replacement: 'Generic'
     model_replacement: 'Feature Phone'
+
+  #########
+  # Apple
+  # @ref: https://www.apple.com/mac/
+  # @note: lookup Mac OS, but exclude iPad, Apple TV, a HTC phone, Kindle, LG
+  # @note: put this at the end, since it is hard to implement contains foo, but not contain bar1, bar 2, bar 3 in go's re2
+  #########
+  - regex: 'Mac OS'
+    device_replacement: 'Mac'
+    brand_replacement: 'Apple'
+    model_replacement: 'Mac'

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1808,6 +1808,16 @@ device_parsers:
     model_replacement: '$1'
 
   #########
+  # Apple
+  # @ref: https://www.apple.com/mac/
+  # @note: lookup Mac OS, but exclude iPad, Apple TV, a HTC phone, Kindle, LG
+  #########
+  - regex: '^(?=.*Mac OS)(?!.*(like Mac|HTC|Silk|LG)).*'
+    device_replacement: 'Mac'
+    brand_replacement: 'Apple'
+    model_replacement: 'Mac'
+
+  #########
   # Archos
   # @ref: http://www.archos.com/de/products/tablets.html
   # @ref: http://www.archos.com/de/products/smartphones/index.html

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -4015,6 +4015,21 @@ test_cases:
     brand: 'Apanda'
     model: 'A80S'
 
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36'
+    family: 'Mac'
+    brand: 'Apple'
+    model: 'Mac'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:73.0) Gecko/20100101 Firefox/73.0'
+    family: 'Mac'
+    brand: 'Apple'
+    model: 'Mac'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15'
+    family: 'Mac'
+    brand: 'Apple'
+    model: 'Mac'
+
   - user_agent_string: 'AppleTV/1.1'
     family: 'AppleTV'
     brand: 'Apple'
@@ -80203,28 +80218,28 @@ test_cases:
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; LG-TP260 Build/NRD90U; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36 Instagram 33.0.0.11.92 Android (24/7.0; 320dpi; 720x1193; LGE/lge; LG-TP260; lv517; lv517; en_US; 93117667)'
     family: 'LG-TP260'
     brand: 'LG'
-    model: 'TP260'    
-    
+    model: 'TP260'
+
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 Instagram 33.0.0.11.96 (iPhone9,3; iOS 11_2_5; en_AU; en-AU; scale=2.00; gamut=wide; 750x1334)'
     family: 'iPhone'
     brand: 'Apple'
     model: 'iPhone9,3'
- 
+
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 Flipboard/4.2.2'
     family: 'iPhone'
     brand: 'Apple'
     model: 'iPhone'
-    
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; SM-G610F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36 Flipboard/4.1.9/4323,4.1.9.4323'
     family: 'Samsung SM-G610F'
     brand: 'Samsung'
     model: 'SM-G610F'
-    
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; SM-G930F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36 Onefootball/Android/9.10.6'
     family: 'Samsung SM-G930F'
     brand: 'Samsung'
     model: 'SM-G930F'
-    
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; SM-A520F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 Flipboard-Briefing/2.7.28'
     family: 'Samsung SM-A520F'
     brand: 'Samsung'


### PR DESCRIPTION
before this change

Mac's device parse result is
```
'device': {   'brand': None, 'family': 'Other', 'model': None},
```

after this change
```
'device': {   'brand': 'Apple', 'family': 'Mac', 'model': 'Mac'},
```
