### PR TITLE
Added ability for iOS GSA UA's to have optional extensions version

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -691,7 +691,7 @@ user_agent_parsers:
     family_replacement: 'TopBuzz'
 
   # @note: iOS / OSX Applications
-  - regex: '(iPod|iPhone|iPad).+GSA/(\d+)\.(\d+)\.(\d+) Mobile'
+  - regex: '(iPod|iPhone|iPad).+GSA/(\d+)\.(\d+)\.(\d+)(?:\.(\d+)|) Mobile'
     family_replacement: 'Google'
   - regex: '(iPod|iPhone|iPad).+Version/(\d+)\.(\d+)(?:\.(\d+)|).*[ +]Safari'
     family_replacement: 'Mobile Safari'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7989,7 +7989,13 @@ test_cases:
     minor: '19'
     patch:
 
-  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0_2 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/36.0.169645775 Mobile/15A421 Safari/604.1'
+- user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) GSA/4.2.2.38484 Mobile/11D257 Safari/9537.53'
+    family: 'Google'
+    major: '4'
+    minor: '2'
+    patch: '2'
+
+- user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0_2 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/36.0.169645775 Mobile/15A421 Safari/604.1'
     family: 'Google'
     major: '36'
     minor: '0'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7989,13 +7989,13 @@ test_cases:
     minor: '19'
     patch:
 
-- user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) GSA/4.2.2.38484 Mobile/11D257 Safari/9537.53'
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) GSA/4.2.2.38484 Mobile/11D257 Safari/9537.53'
     family: 'Google'
     major: '4'
     minor: '2'
     patch: '2'
 
-- user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0_2 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/36.0.169645775 Mobile/15A421 Safari/604.1'
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0_2 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/36.0.169645775 Mobile/15A421 Safari/604.1'
     family: 'Google'
     major: '36'
     minor: '0'


### PR DESCRIPTION
### Issue
Certain Older iOS UA's have a 4th extension parameter in their semantic versioning. 
This was incorrectly being parsed.
eg: 
`Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) GSA/4.2.2.38484 Mobile/11D257 Safari/9537.53`

### Fix
Ensures that versioning works for GSA with older iOS devices by adding an optional parameter in the regex