### PR TITLE
Add regex for AspiegelBot spider

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -156,6 +156,17 @@ user_agent_parsers:
   - regex: '(Twitter for (?:iPhone|iPad)|TwitterAndroid)(?:\/(\d+)\.(\d+)|)'
     family_replacement: 'Twitter'
 
+  # aspiegel.com spider (owned by Huawei)
+  - regex: 'Mozilla.*Mobile.*AspiegelBot'
+    family_replacement: 'Spider'
+    brand_replacement: 'Spider'
+    model_replacement: 'Smartphone'
+
+  - regex: 'AspiegelBot'
+    family_replacement: 'Spider'
+    brand_replacement: 'Spider'
+    model_replacement: 'Desktop'
+
   # Basilisk
   - regex: '(Firefox)/(\d+)\.(\d+) Basilisk/(\d+)'
     family_replacement: 'Basilisk'
@@ -932,6 +943,10 @@ os_parsers:
   # generic HbbTV, hoping to catch manufacturer name (always after 2nd comma) and the first string that looks like a 2011-2019 year
   - regex: 'HbbTV/\d+\.\d+\.\d+ \(.*; ?([a-zA-Z]+) ?;.*(201[1-9]).*\)'
 
+  # aspiegel.com spider (owned by Huawei)
+  - regex: 'AspiegelBot'
+    os_replacement: 'Other'
+
   ##########
   # @note: Windows Phone needs to come before Windows NT 6.1 *and* before Android to catch cases such as:
   # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920)...
@@ -1567,6 +1582,16 @@ device_parsers:
   - regex: 'X11; Datanyze; Linux'
     device_replacement: 'Spider'
     brand_replacement: 'Spider'
+
+  # aspiegel.com spider (owned by Huawei)
+  - regex: 'Mozilla.*Mobile.*AspiegelBot'
+    device_replacement: 'Spider'
+    brand_replacement: 'Spider'
+    model_replacement: 'Smartphone'
+  - regex: 'Mozilla.*AspiegelBot'
+    device_replacement: 'Spider'
+    brand_replacement: 'Spider'
+    model_replacement: 'Desktop'
 
   #########
   # WebBrowser for SmartWatch

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -80324,3 +80324,13 @@ test_cases:
     family: 'KYT33'
     brand: 'Generic_Android_Tablet'
     model: 'KYT33'
+
+  - user_agent_string: 'Mozilla/5.0 (compatible;AspiegelBot)'
+    family: 'Spider'
+    brand: 'Spider'
+    model: 'Desktop'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)'
+    family: 'Spider'
+    brand: 'Spider'
+    model: 'Smartphone'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2867,3 +2867,17 @@ test_cases:
     minor:
     patch:
     patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (compatible;AspiegelBot)'
+    family: 'Other'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)'
+    family: 'Other'
+    major:
+    minor:
+    patch:
+    patch_minor:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8117,3 +8117,15 @@ test_cases:
     minor: '1'
     patch: '35'
     patch_minor: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (compatible;AspiegelBot)'
+    family: 'AspiegelBot'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)'
+    family: 'AspiegelBot'
+    major:
+    minor:
+    patch:


### PR DESCRIPTION
As per #469, adding support for AspiegelBot, a new spider owned by Huawei.