### PR TITLE
Add regexes for Edge Chromium on iOS and Android

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -312,6 +312,10 @@ user_agent_parsers:
   - regex: 'Windows Phone .*(Edge)/(\d+)\.(\d+)'
     family_replacement: 'Edge Mobile'
 
+  # Edge Mobile (Chromium)
+  - regex: '(EdgiOS|EdgA)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Edge Mobile'
+
   # Samsung Internet (based on Chrome, but lacking some features)
   - regex: '(SamsungBrowser)/(\d+)\.(\d+)'
     family_replacement: 'Samsung Internet'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -6831,6 +6831,18 @@ test_cases:
     minor: '0'
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 EdgiOS/44.5.0.10 Mobile/15E148 Safari/604.1'
+    family: 'Edge Mobile'
+    major: '44'
+    minor: '5'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPM4.171019.021.D1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36 EdgA/42.0.0.2057'
+    family: 'Edge Mobile'
+    major: '42'
+    minor: '0'
+    patch: '0'
+
   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.11 Chrome/47.0.2526.110 Brave/0.36.5 Safari/537.36'
     family: 'Brave'
     major: '0'


### PR DESCRIPTION
Edge Chromium on iOS and Android have new user agents. Added a regex that handles them so they are detected properly as Edge Mobile.

Fixes https://github.com/ua-parser/uap-core/issues/328