### PR TITLE
Merge Python aiohttp under one Family

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -843,8 +843,7 @@ user_agent_parsers:
 
   # Asynchronous HTTP Client/Server for asyncio and Python (https://aiohttp.readthedocs.io/)
   - regex: '(Python/3\.\d{1,3} aiohttp)/(\d+)\.(\d+)\.(\d+)'
-  # Asynchronous HTTP Client/Server for asyncio and Python (https://aiohttp.readthedocs.io/)
-  - regex: '(Python/3\.\d{1,3} aiohttp)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Python aiohttp'
 
   - regex: '(Java)[/ ]?\d+\.(\d+)\.(\d+)[_-]*([a-zA-Z0-9]+|)'
 

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7784,7 +7784,7 @@ test_cases:
     patch: '10'
 
   - user_agent_string: 'Python/3.6 aiohttp/3.5.4'
-    family: 'Python/3.6 aiohttp'
+    family: 'Python aiohttp'
     major: '3'
     minor: '5'
     patch: '4'


### PR DESCRIPTION
Merges `aiohttp` running under various Python versions to go under a single UA Family, `Python aiohttp`. Also removes the duplicate regex entry for `aiohttp`.