### PR TITLE
fix(#473): EdgeMobile simplify and remove duplicated rule

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -328,12 +328,6 @@ user_agent_parsers:
   # Edge Mobile
   - regex: 'Windows Phone .*(Edge)/(\d+)\.(\d+)'
     family_replacement: 'Edge Mobile'
-  - regex: '(EdgA)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
-    family_replacement: 'Edge Mobile'
-  - regex: '(EdgiOS)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
-    family_replacement: 'Edge Mobile'
-
-  # Edge Mobile (Chromium)
   - regex: '(EdgiOS|EdgA)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Edge Mobile'
 


### PR DESCRIPTION
EdgeMobile rule is duplicated as of #473 
This PR simplifies the present rule and removes the duplicate rule