### PR TITLE
Rename "Chrome Mobile iOS" -> "Chrome Mobile"

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -449,7 +449,7 @@ user_agent_parsers:
   - regex: '(CrMo)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile'
   - regex: '(CriOS)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
-    family_replacement: 'Chrome Mobile iOS'
+    family_replacement: 'Chrome Mobile'
   - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+) Mobile(?:[ /]|$)'
     family_replacement: 'Chrome Mobile'
   - regex: ' Mobile .*(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'


### PR DESCRIPTION
Seems "iOS" is duplicate with the os property and not necessary