### PR TITLE
Fix AspiegelBot's user_agent_parsers section

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -215,13 +215,9 @@ user_agent_parsers:
   # aspiegel.com spider (owned by Huawei)
   - regex: 'Mozilla.*Mobile.*AspiegelBot'
     family_replacement: 'Spider'
-    brand_replacement: 'Spider'
-    model_replacement: 'Smartphone'
 
   - regex: 'AspiegelBot'
     family_replacement: 'Spider'
-    brand_replacement: 'Spider'
-    model_replacement: 'Desktop'
 
   # Basilisk
   - regex: '(Firefox)/(\d+)\.(\d+) Basilisk/(\d+)'


### PR DESCRIPTION
I'm removing the brand_replacement & model_replacement values from user_agent_parsers section for aspiegel.com. These settings belong in the device_parsers section and are indeed present there around line 1644