### PR TITLE
Add support for DuckDuckGo Mobile

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -441,6 +441,10 @@ user_agent_parsers:
   - regex: '(QQBrowser)(?:/(\d+)(?:\.(\d+)\.(\d+)(?:\.(\d+)|)|)|)'
     family_replacement: 'QQ Browser'
 
+  # DuckDuckGo
+  - regex: 'Mobile.*(DuckDuckGo)/(\d+)'
+    family_replacement: 'DuckDuckGo Mobile'
+
   # Chrome Mobile
   - regex: 'Version/.+(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile WebView'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -80434,3 +80434,13 @@ test_cases:
     family: 'Spider'
     brand: 'Spider'
     model: 'Smartphone'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.3 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15'
+    family: 'iPhone'
+    brand: 'Apple'
+    model: 'iPhone'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/87.0.4280.141 Mobile DuckDuckGo/5 Safari/537.36'
+    family: 'Generic Smartphone'
+    brand: 'Generic'
+    model: 'Smartphone'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2881,3 +2881,17 @@ test_cases:
     minor:
     patch:
     patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.3 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15'
+    family: 'iOS'
+    major: '14'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/87.0.4280.141 Mobile DuckDuckGo/5 Safari/537.36'
+    family: 'Android'
+    major: '11'
+    minor:
+    patch:
+    patch_minor:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8334,3 +8334,15 @@ test_cases:
     major: '100'
     minor: '7'
     patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.3 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15'
+    family: 'DuckDuckGo Mobile'
+    major: '7'
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/87.0.4280.141 Mobile DuckDuckGo/5 Safari/537.36'
+    family: 'DuckDuckGo Mobile'
+    major: '5'
+    minor:
+    patch:


### PR DESCRIPTION
Simply adds support for DuckDuckGo Mobile apps on iOS and Android.

Thanks in advance!