### PR TITLE
Add HTTrack crawler regex

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -981,7 +981,7 @@ user_agent_parsers:
     family_replacement: 'ViaFree'
 
   # HTTrack crawler
-  - regex: '\b(HTTrack) (\d+)\.(\d+)(?:[\.\-](\d+))?'
+  - regex: '\b(HTTrack) (\d+)\.(\d+)(?:[\.\-](\d+)|)'
 
 os_parsers:
   ##########

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -980,6 +980,9 @@ user_agent_parsers:
   - regex: '^(ViaFree|Viafree)-(?:tvOS-)?[A-Z]{2}/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'ViaFree'
 
+  # HTTrack crawler
+  - regex: '\b(HTTrack) (\d+)\.(\d+)(?:[\.\-](\d+))?'
+
 os_parsers:
   ##########
   # HbbTV vendors

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8568,3 +8568,9 @@ test_cases:
     major:  '1'
     minor:  '0'
     patch:
+
+  - user_agent_string: 'Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)'
+    family: 'HTTrack'
+    major:  '3'
+    minor:  '0'
+    patch:


### PR DESCRIPTION
Added a regex to "user_agent_parsers" for HTTrack web crawler. It was added at the end of the list because nothing seems to match it at the moment.

A sample UserAgent:
Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)

According to https://developers.whatismybrowser.com/useragents/explore/software_type_specific/web-browser/4 this user agent is in the top few hundred most "popular" user agents, listed as "Very Common".