### PR TITLE
Fix: As iOS & tvOS, watchOS apps can have ' ' or / before version digits

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1528,7 +1528,7 @@ os_parsers:
   ##########
   # Apple Watch
   ##########
-  - regex: '(watchOS)/(\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '(watchOS)[/ ](\d+)\.(\d+)(?:\.(\d+)|)'
     os_replacement: 'WatchOS'
 
   ##########################

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -21,6 +21,13 @@ test_cases:
     patch: '1'
     patch_minor:
 
+  - user_agent_string: 'BBCNewsUKWatchApp/4.3.0 (Watch1,2; watchOS 3.2.2)'
+    family: 'WatchOS'
+    major: '3'
+    minor: '2'
+    patch: '2'
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true'
     family: 'Android'
     major:


### PR DESCRIPTION
**The change**:

Transformed the Apple Watch regex to: `(watchOS)[/ ](\d+)\.(\d+)(?:\.(\d+)|)`; thus adding space as a valid separator before version digits.

**More details**:

Having both ` ` and `/` as a separator for version digits was already being taken into account in other cases:

- For tvOS: `(tvOS)[/ ](\d+)\.(\d+)(?:\.(\d+)|)` ([see](https://github.com/ua-parser/uap-core/blob/master/regexes.yaml#L1548))
- For iOS apps there is a fragment: `iOS[ /]` ([see](https://github.com/ua-parser/uap-core/blob/master/regexes.yaml#L1524))

However, for watchOS only the slash was being taken into account as a separator: `(watchOS)/(\d+)\.(\d+)(?:\.(\d+)|)`; so I have replicated the same pattern used for iOS apps and for tvOS there.