### PR TITLE
Handle Edge on iOS with only major.minor.patch versions

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -381,7 +381,7 @@ user_agent_parsers:
   # Edge Mobile
   - regex: 'Windows Phone .{0,200}(Edge)/(\d+)\.(\d+)'
     family_replacement: 'Edge Mobile'
-  - regex: '(EdgiOS|EdgA)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+  - regex: '(EdgiOS|EdgA)/(\d+)\.(\d+)\.(\d+)(?:\.(\d+)|)'
     family_replacement: 'Edge Mobile'
 
   # Samsung Internet (based on Chrome, but lacking some features)

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -6938,6 +6938,12 @@ test_cases:
     minor: '5'
     patch: '0'
 
+  - user_agent_string: 'Mozilla/5.0 (iPad; CPU OS 12_5_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 EdgiOS/46.3.26 Mobile/15E148 Safari/605.1.15'
+    family: 'Edge Mobile'
+    major: '46'
+    minor: '3'
+    patch: '26'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPM4.171019.021.D1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36 EdgA/42.0.0.2057'
     family: 'Edge Mobile'
     major: '42'
@@ -8628,4 +8634,3 @@ test_cases:
     major: '7'
     minor: '20'
     patch: '1'
-


### PR DESCRIPTION
It seems like Edge on iOS started using only 3 parts in their version string. The UA string added to tests was caught in the wild.