### PR TITLE
Remove last Dell regex that will never reach

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -2461,10 +2461,6 @@ device_parsers:
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: '$1'
-  - regex: '; {0,2}Dell ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
-    device_replacement: 'Dell $1'
-    brand_replacement: 'Dell'
-    model_replacement: '$1'
 
   #########
   # Denver


### PR DESCRIPTION
Lower is subset of higher precedence [ ] ⊆ [ _]
for example "; Dell ABC) AppleWebKit" match both
1. '; {0,2}Dell\[ _\]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
2. '; {0,2}Dell ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
but option 2. will never reach and all replacement both 1. and 2. is the same it's no need to change precedence.