### PR TITLE
Device list

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "devDependencies": {
-    "mocha": "^9.1.2",
+    "mocha": "^9.2.2",
     "safe-regex": "^2.1.1",
     "uap-ref-impl": "git+https://github.com/ua-parser/uap-ref-impl#master",
     "yamlparser": "^0.0.2"

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -2671,10 +2671,14 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'Google'
     model_replacement: '$1'
-  - regex: '; {0,2}(Pixel.{0,200}?)(?: Build|\) AppleWebKit)'
-    device_replacement: '$1'
+  - regex: '; {0,2}([g|G]oogle)? (Pixel[ a-zA-z0-9]{1,100});(?: Build|.{0,50}\) AppleWebKit)'
+    device_replacement: '$2'
     brand_replacement: 'Google'
-    model_replacement: '$1'
+    model_replacement: '$2'
+  - regex: '; {0,2}([g|G]oogle)? (Pixel.{0,200}?)(?: Build|\) AppleWebKit)'
+    device_replacement: '$2'
+    brand_replacement: 'Google'
+    model_replacement: '$2'
 
   #########
   # Gigabyte
@@ -3799,6 +3803,18 @@ device_parsers:
     model_replacement: '$1'
   - regex: '; (ONEPLUS [a-zA-Z]\d+)(?: Build|\) AppleWebKit)'
     device_replacement: 'OnePlus $1'
+    brand_replacement: 'OnePlus'
+    model_replacement: '$1'
+  - regex: '; {0,2}(HD1903|GM1917|IN2025|LE2115|LE2127|HD1907|BE2012|BE2025|BE2026|BE2028|BE2029|DE2117|DE2118|EB2101|GM1900|GM1910|GM1915|HD1905|HD1925|IN2015|IN2017|IN2019|KB2005|KB2007|LE2117|LE2125|BE2015|GM1903|HD1900|HD1901|HD1910|HD1913|IN2010|IN2013|IN2020|LE2111|LE2120|LE2121|LE2123|BE2011|IN2023|KB2003|LE2113|NE2215|DN2101)(?: Build|\) AppleWebKit)'
+    device_replacement: 'OnePlus $1'
+    brand_replacement: 'OnePlus'
+    model_replacement: 'OnePlus $1'
+  - regex: '; (OnePlus[ a-zA-z0-9]{0,50});((?: Build|.{0,50}\) AppleWebKit))'
+    device_replacement: '$1'
+    brand_replacement: 'OnePlus'
+    model_replacement: '$1'
+  - regex: '; (OnePlus[ a-zA-z0-9]{0,50})((?: Build|\) AppleWebKit))'
+    device_replacement: '$1'
     brand_replacement: 'OnePlus'
     model_replacement: '$1'
 
@@ -5481,6 +5497,15 @@ device_parsers:
     device_replacement: 'Motorola $1'
     brand_replacement: 'Motorola'
     model_replacement: '$1'
+  - regex: '; (moto[ a-zA-z0-9()]{0,50});((?: Build|.{0,50}\) AppleWebKit))'
+    device_replacement: '$1'
+    brand_replacement: 'Motorola'
+    model_replacement: '$1'
+  - regex: '; {0,2}(moto)(.{0,50})(?: Build|\) AppleWebKit)'
+    device_replacement: 'Motorola$2'
+    brand_replacement: 'Motorola'
+    model_replacement: '$2'
+  
 
   ##########
   # nintendo

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -80494,3 +80494,60 @@ test_cases:
     brand:
     model:
 
+  - user_agent_string: 'com.abc.mobile/5.7.14/Mozilla/5.0 (Linux; Android 9; Google Pixelbook Go Build/R99-14469.59.0; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/99.0.4844.73 Safari/537.36'
+    family: 'Pixelbook Go'
+    brand:  'Google'
+    model:  'Pixelbook Go'
+
+  - user_agent_string: 'ABC/4.3.392 version 6.2.15, build 392 (Pixel 6 Pro; google Pixel 6 Pro; Android 12) AppleWebKit'
+    family: 'Pixel 6 Pro'
+    brand:  'Google'
+    model:  'Pixel 6 Pro'
+
+  - user_agent_string: 'ABC NP3/4.3.397 version 6.3.10b4.1, build 397 (Android SDK built for x86; google Android SDK built for x86; Android 10)'
+    family: 'Generic Smartphone'
+    brand:  'Generic'
+    model:  'Smartphone'
+
+  - user_agent_string: 'com.fi.abc/5.7.18/Mozilla/5.0 (Linux; Android 11; OnePlus8Pro Build/QKR1.191246.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/90.0.4430.210 Mobile Safari/537.36'
+    family: 'OnePlus8Pro'
+    brand: 'OnePlus'
+    model: 'OnePlus8Pro'
+
+  - user_agent_string: 'ABC NP3/4.3.398 version 6.3.24b5.1, build 398 (GM1910; OnePlus GM1910; Android 11) AppleWebKit'
+    family: 'OnePlus GM1910'
+    brand: 'OnePlus'
+    model: 'OnePlus GM1910'
+
+  - user_agent_string: 'org.xyz.mobile/5.7.09/Mozilla/5.0 (Linux; Android 11; GM1917 Build/RKQ1.201022.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/99.0.4844.88 Mobile Safari/537.36'
+    family: 'OnePlus GM1917'
+    brand: 'OnePlus'
+    model: 'OnePlus GM1917'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 11; GM1917) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Mobile Safari/537.36'
+    family: 'OnePlus GM1917'
+    brand: 'OnePlus'
+    model: 'OnePlus GM1917'
+
+  - user_agent_string: 'ABC/4.3.385 version 6.2.7, build 385 (GM1917; OnePlus GM1917; Android 11) AppleWebKit'
+    family: 'OnePlus GM1917'
+    brand: 'OnePlus'
+    model: 'OnePlus GM1917'
+
+  - user_agent_string: 'com.abc.mobile.production/5.7.17/Mozilla/5.0 (Linux; Android 9; moto e6 (XT2005DL) Build/PPBS29.73-81-5-14-5-4-2-6-7; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/100.0.4896.79 Mobile Safari/537.36'
+    family: 'Motorola e6 (XT2005DL)'
+    brand: 'Motorola'
+    model: 'e6 (XT2005DL)'
+
+  - user_agent_string: 'ABC/4.3.392 version 6.2.15, build 392 (moto g stylus; motorola moto g stylus; Android 11) AppleWebKit'
+    family: 'motorola moto g stylus'
+    brand: 'Motorola'
+    model: 'motorola moto g stylus'
+
+  - user_agent_string: 'ABC/4.3.392 version 6.2.15, build 392 (moto g play (2021); motorola moto g play (2021); Android 11) AppleWebKit'
+    family: 'motorola moto g play (2021)'
+    brand: 'Motorola'
+    model: 'motorola moto g play (2021)'
+
+
+  


### PR DESCRIPTION
This PR includes regex to address missing user agent string patterns for  Oneplus, Pixel and Motorola. 
Currently the parser identifies them as Generic Smartphone or Generic_Android

Changes done:
Oneplus - Included regex to identify Oneplus devices by a set of model names
Pixel - Included regex to identify Google Pixelbook
Motorola - Included regex to identify moto devices that are missed due to lower case 'moto' from the source

Tests have been included for the modifications 