### PR TITLE
Fix Firefox regex to handle version without patch segment

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -5550,7 +5550,6 @@ device_parsers:
     brand_replacement: 'Motorola'
     model_replacement: '$2'
 
-
   ##########
   # nintendo
   ##########

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -921,7 +921,7 @@ user_agent_parsers:
   # AFTER THE EDGE CASES ABOVE!
   # AFTER IE11
   # BEFORE all other IE
-  - regex: '(Firefox)/(\d+)\.(\d+)(?:\.(\d+)|\z)'
+  - regex: '(Firefox)/(\d+)\.(\d+)(?:\.(\d+)|$)'
   - regex: '(Firefox)/(\d+)\.(\d+)(pre|[ab]\d+[a-z]*|)'
 
 

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -921,7 +921,7 @@ user_agent_parsers:
   # AFTER THE EDGE CASES ABOVE!
   # AFTER IE11
   # BEFORE all other IE
-  - regex: '(Firefox)/(\d+)\.(\d+)\.(\d+)'
+  - regex: '(Firefox)/(\d+)\.(\d+)(?:\.(\d+)|)'
   - regex: '(Firefox)/(\d+)\.(\d+)(pre|[ab]\d+[a-z]*|)'
 
 
@@ -5549,7 +5549,7 @@ device_parsers:
     device_replacement: 'Motorola$2'
     brand_replacement: 'Motorola'
     model_replacement: '$2'
-  
+
 
   ##########
   # nintendo

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -921,7 +921,7 @@ user_agent_parsers:
   # AFTER THE EDGE CASES ABOVE!
   # AFTER IE11
   # BEFORE all other IE
-  - regex: '(Firefox)/(\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '(Firefox)/(\d+)\.(\d+)(?:\.(\d+)|\z)'
   - regex: '(Firefox)/(\d+)\.(\d+)(pre|[ab]\d+[a-z]*|)'
 
 
@@ -5549,6 +5549,7 @@ device_parsers:
     device_replacement: 'Motorola$2'
     brand_replacement: 'Motorola'
     model_replacement: '$2'
+
 
   ##########
   # nintendo

--- a/test_resources/firefox_user_agent_strings.yaml
+++ b/test_resources/firefox_user_agent_strings.yaml
@@ -1234,6 +1234,12 @@ test_cases:
     minor: '0'
     patch: '1'
 
+  - user_agent_string: 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0'
+    family: 'Firefox'
+    major: '104'
+    minor: '0'
+    patch:
+
   - user_agent_string: 'Mozilla/5.0 (X11; Linux armv7l; rv:2.1.1) Gecko/ Firefox/5.0.1'
     family: 'Firefox'
     major: '5'


### PR DESCRIPTION
Update regex to allow patch segment as optional.

### Current Issue
When parsing `'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0'` to https://github.com/ua-parser/uap-ruby, `#<MatchData "Firefox/103.0" 1:"Firefox" 2:"104" 3:"0" 4:"">` is returned which interpolates to `Firefox 104.0.` (Notice the additional `.` here due to the empty string in the patch segment)

### Solution
With the updated regex, patch segment is optional such that it returns `Firefox 104.0` if it's not provided