### PR TITLE
fix: add support for httpie user agent

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -932,7 +932,7 @@ user_agent_parsers:
     family_replacement: 'Python Requests'
 
   # headless user-agents
-  - regex: '\b(Windows-Update-Agent|WindowsPowerShell|Microsoft-CryptoAPI|SophosUpdateManager|SophosAgent|Debian APT-HTTP|Ubuntu APT-HTTP|libcurl-agent|libwww-perl|urlgrabber|curl|PycURL|Wget|wget2|aria2|Axel|OpenBSD ftp|lftp|jupdate|insomnia|fetch libfetch|akka-http|got|CloudCockpitBackend|ReactorNetty|axios|Jersey|Vert.x-WebClient|Apache-CXF|Go-CF-client|go-resty|AHC)(?:[ /](\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+  - regex: '\b(Windows-Update-Agent|WindowsPowerShell|Microsoft-CryptoAPI|SophosUpdateManager|SophosAgent|Debian APT-HTTP|Ubuntu APT-HTTP|libcurl-agent|libwww-perl|urlgrabber|curl|PycURL|Wget|wget2|aria2|Axel|OpenBSD ftp|lftp|jupdate|insomnia|fetch libfetch|akka-http|got|CloudCockpitBackend|ReactorNetty|axios|Jersey|Vert.x-WebClient|Apache-CXF|Go-CF-client|go-resty|AHC|HTTPie)(?:[ /](\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
 
   # CloudFoundry
   - regex: '^(cf)\/(\d+)\.(\d+)\.(\S+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8657,3 +8657,9 @@ test_cases:
     major: '2'
     minor: '7'
     patch: '6'
+
+  - user_agent_string: 'HTTPie/3.2.1'
+    family: 'HTTPie'
+    major: '3'
+    minor: '2'
+    patch: '1'


### PR DESCRIPTION
[HTTPie](https://httpie.io/docs/cli/examples) is a very popular tool similar to `cURL` and `wget`.
This PR introduces support for parsing its default user agent.