### PR TITLE
Rename 'Mac OS X' to 'macOS'

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1260,39 +1260,39 @@ os_parsers:
 
   ##########
   # Mac OS
-  # @ref: http://en.wikipedia.org/wiki/Mac_OS_X#Versions
+  # @ref: https://en.wikipedia.org/wiki/MacOS#Versions
   # @ref: http://www.puredarwin.org/curious/versions
   ##########
   - regex: '((?:Mac[ +]?|; )OS[ +]X)[\s+/](?:(\d+)[_.](\d+)(?:[_.](\d+)|)|Mach-O)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
   - regex: 'Mac OS X\s.{1,50}\s(\d+).(\d+).(\d+)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '$1'
     os_v2_replacement: '$2'
     os_v3_replacement: '$3'
   # Leopard
   - regex: ' (Dar)(win)/(9).(\d+).{0,100}\((?:i386|x86_64|Power Macintosh)\)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '5'
   # Snow Leopard
   - regex: ' (Dar)(win)/(10).(\d+).{0,100}\((?:i386|x86_64)\)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '6'
   # Lion
   - regex: ' (Dar)(win)/(11).(\d+).{0,100}\((?:i386|x86_64)\)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '7'
   # Mountain Lion
   - regex: ' (Dar)(win)/(12).(\d+).{0,100}\((?:i386|x86_64)\)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '8'
   # Mavericks
   - regex: ' (Dar)(win)/(13).(\d+).{0,100}\((?:i386|x86_64)\)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '9'
   # Yosemite is Darwin/14.x but patch versions are inconsistent in the Darwin string;
@@ -1306,10 +1306,11 @@ os_parsers:
 
   # ios devices spoof (mac os x), so including intel/ppc prefixes
   - regex: '(?:PPC|Intel) (Mac OS X)'
+    os_replacement: 'macOS'
 
   # Box Drive and Box Sync on Mac OS X use OSX version numbers, not Darwin
   - regex: '^Box.{0,200};(Darwin)/(10)\.(1\d)(?:\.(\d+)|)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
 
   ##########
   # iOS
@@ -1363,11 +1364,11 @@ os_parsers:
     os_replacement: 'iOS'
     os_v1_replacement: '8'
   - regex: '(CF)(Network)/(720)\.(\d)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '10'
   - regex: '(CF)(Network)/(760)\.(\d)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '11'
   - regex: 'CFNetwork/7.{0,100} Darwin/15\.4\.\d+'
@@ -1402,15 +1403,15 @@ os_parsers:
   # @ref: https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
   ##########
   - regex: 'CFNetwork/.{0,100} Darwin/17\.\d+.{0,100}\(x86_64\)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '13'
   - regex: 'CFNetwork/.{0,100} Darwin/16\.\d+.{0,100}\(x86_64\)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '12'
   - regex: 'CFNetwork/8.{0,100} Darwin/15\.\d+.{0,100}\(x86_64\)'
-    os_replacement: 'Mac OS X'
+    os_replacement: 'macOS'
     os_v1_replacement: '10'
     os_v2_replacement: '11'
   ##########
@@ -5549,7 +5550,7 @@ device_parsers:
     device_replacement: 'Motorola$2'
     brand_replacement: 'Motorola'
     model_replacement: '$2'
-  
+
 
   ##########
   # nintendo

--- a/test_resources/additional_os_tests.yaml
+++ b/test_resources/additional_os_tests.yaml
@@ -85,7 +85,7 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X Mach-O; en-en; rv:1.9.0.12) Gecko/2009070609 Firefox/3.0.12,gzip(gfe),gzip(gfe)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major:
     minor:
     patch:

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -428,21 +428,21 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/418.8 (KHTML, like Gecko) Safari/419.3'
-    family: 'Mac OS X'
+    family: 'macOS'
     major:
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; en-us) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/2.0'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '5'
     patch: '7'
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.18.1 (KHTML, like Gecko) Version/5.0.2 Safari/533.18.5'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '6'
     patch: '5'
@@ -456,7 +456,7 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'MacOutlook/16.12.0.180401 (Intelx64 Mac OS X Version 10.12.6 (build 16G29))'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '12'
     patch: '6'
@@ -1894,42 +1894,42 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Safari5530.17 CFNetwork/438.12 Darwin/9.7.0 (i386) (Macmini2,1)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '5'
     patch: '7'
     patch_minor:
 
   - user_agent_string: 'Safari5531.21.10 CFNetwork/438.14 Darwin/9.8.0 (i386) (MacBook5%2C2)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '5'
     patch: '8'
     patch_minor:
 
   - user_agent_string: 'Safari/6533.18.5 CFNetwork/454.9.8 Darwin/10.4.0 (i386) (MacBookPro7,1)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '6'
     patch: '4'
     patch_minor:
 
   - user_agent_string: 'Safari/7536.30.1 CFNetwork/520.5.1 Darwin/11.4.2 (i386) (MacBook3,1)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '7'
     patch: '4'
     patch_minor:
 
   - user_agent_string: 'Reader Notifier/5 CFNetwork/596.3.3 Darwin/12.3.0 (x86_64) (MacBookPro7,1)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '8'
     patch: '3'
     patch_minor:
 
   - user_agent_string: 'Safari/9537.71 CFNetwork/673.0.2 Darwin/13.0.1 (x86_64) (MacBookPro11,1)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '9'
     patch: '0'
@@ -1943,21 +1943,21 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Safari/10600.3.18 CFNetwork/720.2.4 Darwin/14.1.0 (x86_64)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '10'
     patch: '2'
     patch_minor:
 
   - user_agent_string: 'com.apple.geod/1077.0.18 CFNetwork/720.4 Darwin/14.4.0 (x86_64)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '10'
     patch: '4'
     patch_minor:
 
   - user_agent_string: 'Mac OS X/10.10.4 (14E11f)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '10'
     patch: '4'
@@ -2146,7 +2146,7 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Bloodhound/2.1 CFNetwork/673.4 Darwin/13.3.0 (x86_64) (MacBookPro10%2C1)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '9'
     patch: '3'
@@ -2489,28 +2489,28 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'MacAppStore/2.0 (Macintosh; OS X 10.10.2; 14C81f) AppleWebKit/0600.3.10.2'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '10'
     patch: '2'
     patch_minor:
 
   - user_agent_string: 'iTunes/12.0.1 (Macintosh; OS X 10.9.2) AppleWebKit/537.74.9'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '9'
     patch: '2'
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; MacOS X 10_10_2; en-US; Valve Steam Client/1424305157; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.86 Safari/537.36'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '10'
     patch: '2'
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Mac OS X Mach-O; en-US; rv:2.0a) Gecko/20040614 Firefox/3.0.0'
-    family: 'Mac OS X'
+    family: 'macOS'
     major:
     minor:
     patch:
@@ -2749,35 +2749,35 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0+(Macintosh;+Intel+Mac+OS+X+10_11_6)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/52.0.2743.116+Safari/537.36'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '11'
     patch: '6'
     patch_minor:
 
   - user_agent_string: 'Safari/12602.2.14.0.7 CFNetwork/807.1.3 Darwin/16.1.0 (x86_64)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '12'
     patch:
     patch_minor:
 
   - user_agent_string: 'Box Sync/4.0.7848;Darwin/10.13;i386/64bit'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '13'
     patch:
     patch_minor:
 
   - user_agent_string: 'Box/1.2.93;Darwin/10.13;i386/64bit'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '13'
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_0) AppleWebKit/537.36 (KHTML, like Gecko) BoxNotes/1.3.0 Chrome/56.0.2924.87 Electron/1.6.8 Safari/537.36'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '13'
     patch: '0'
@@ -2882,7 +2882,7 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'MyApp/1.0 CFNetwork/893.13.1 Darwin/17.3.0 (x86_64)'
-    family: 'Mac OS X'
+    family: 'macOS'
     major: '10'
     minor: '13'
     patch:


### PR DESCRIPTION
Since 2016 it's officially named macOS:
https://en.wikipedia.org/wiki/MacOS

This is a separate change similar to the PR which has been open for a while and which has merge conflicts:

https://github.com/ua-parser/uap-core/pull/482

Also my version comes with less gratuitous whitespace changes :D