### PR TITLE
Parse modern Java versions

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -961,7 +961,9 @@ user_agent_parsers:
   - regex: '(Python/3\.\d{1,3} aiohttp)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Python aiohttp'
 
-  - regex: '(Java)[/ ]?\d+\.(\d+)\.(\d+)[_-]*([a-zA-Z0-9]+|)'
+  - regex: '(Java)[/ ]?\d{1}\.(\d+)\.(\d+)[_-]*([a-zA-Z0-9]+|)'
+
+  - regex: '(Java)[/ ]?(\d+)\.(\d+)\.(\d+)'
 
   # minio-go (https://github.com/minio/minio-go)
   - regex: '(minio-go)/v(\d+)\.(\d+)\.(\d+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -551,6 +551,12 @@ test_cases:
     minor: '0'
     patch: '25'
 
+  - user_agent_string: 'Java/17.0.6'
+    family: 'Java'
+    major: '17'
+    minor: '0'
+    patch: '6'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; U; en-US) AppleWebKit/528.5+ (KHTML, like Gecko, Safari/528.5+) Version/4.0 Kindle/3.0 (screen 600x800; rotate)'
     family: 'Kindle'
     major: '3'


### PR DESCRIPTION
Parse modern Java versions like "Java/17.0.6" and legacy versions like "Java/1.8.0_362"