### PR TITLE
Update UA for Ladybird Browser (previously SerenityOS Browser)

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1022,10 +1022,9 @@ user_agent_parsers:
   # HTTrack crawler
   - regex: '\b(HTTrack) (\d+)\.(\d+)(?:[\.\-](\d+)|)'
 
-  # SerenityOS (https://serenityos.org)
-  # https://github.com/SerenityOS/serenity/blob/2e1bbcb0faeae92d7595b8e0b022a8cdcecca07e/Userland/Libraries/LibWeb/Loader/ResourceLoader.h#L27
-  - regex: 'SerenityOS'
-    family_replacement: 'SerenityOS Browser'
+  # Ladybird Browser (https://ladybird.dev)
+  # https://github.com/SerenityOS/serenity/blob/8da9ff24e4e720b1e80a027f09c419ac9503f896/Userland/Libraries/LibWeb/Loader/ResourceLoader.h#L52
+  - regex: 'LibWeb\+LibJS\/\d+\.\d+ (Ladybird)\/(\d+)\.(\d+)'
 
 os_parsers:
   ##########

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -3217,7 +3217,7 @@ test_cases:
     patch:
     patch_minor:
 
-  - user_agent_string: 'Mozilla/4.0 (SerenityOS; x86_64) LibWeb+LibJS (Not KHTML, nor Gecko) LibWeb'
+  - user_agent_string: 'Mozilla/5.0 (SerenityOS; x86_64) LibWeb+LibJS/1.0 Ladybird/1.0'
     family: 'SerenityOS'
     major:
     minor:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8664,10 +8664,10 @@ test_cases:
     minor: '20'
     patch: '1'
 
-  - user_agent_string: 'Mozilla/4.0 (SerenityOS; x86_64) LibWeb+LibJS (Not KHTML, nor Gecko) LibWeb'
-    family: 'SerenityOS Browser'
-    major:
-    minor:
+  - user_agent_string: 'Mozilla/5.0 (Linux; x86_64) LibWeb+LibJS/1.0 Ladybird/1.0'
+    family: 'Ladybird'
+    major: '1'
+    minor: '0'
     patch:
 
   - user_agent_string: 'surveyon/2.7.6 Mobile (Android: 11; MODEL:CPH2127; PRODUCT:CPH2127T2; MANUFACTURER:OPPO;)'


### PR DESCRIPTION
The browser has always been called 'Ladybird' outside SerenityOS, and now is even called Ladybird in Serenity (see https://github.com/SerenityOS/serenity/commit/15211cd753440c16db4526b94e9c0d8eb85ea351).

The format of the user agent has also changed since it was first added here. Given the nature of the Ladybird project it's highly unlikely there's any users of the old version, so that UA probably does not need to be preserved. 

cc @linusg 