### PR TITLE
Proper parsing of newer aws sdks

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -152,7 +152,7 @@ user_agent_parsers:
 
   # AWS S3 Clients
   # must come before "Bots General matcher" to catch "boto"/"boto3" before "bot"
-  - regex: '\b(Boto3?|JetS3t|aws-(?:cli|sdk-(?:cpp|go|java|nodejs|ruby2?|dotnet-(?:\d{1,2}|core)))|s3fs)/(\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '\b(Boto3?|JetS3t|aws-(?:cli|sdk-(?:cpp|go(?:-v2)?|java|js|nodejs|ruby(?:2|3)?|dotnet-(?:\d{1,2}|core)))|s3fs)/(\d+)\.(\d+)(?:\.(\d+)|)'
 
   # SAFE FME
   - regex: '(FME)\/(\d+\.\d+)\.(\d+)\.(\d+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7938,6 +7938,12 @@ test_cases:
     major: '2'
     minor: '2'
     patch: '18'
+  
+  - user_agent_string: 'aws-sdk-ruby3/3.170 ruby/3.0 x86_64-linux-musl aws-sdk-core/3.170'
+    family: 'aws-sdk-ruby3'
+    major: '3'
+    minor: '170'
+    patch: 0
 
   - user_agent_string: 'aws-sdk-cpp/1.0.64 Linux/4.4.0-66-generic x86_64'
     family: 'aws-sdk-cpp'
@@ -7950,12 +7956,24 @@ test_cases:
     major: '1'
     minor: '4'
     patch: '12'
+   
+  - user_agent_string: 'aws-sdk-go-v2/1.18 os/linux lang/go/1.20 md/GOOS/linux md/GOARCH/amd64 api/sts/1.18'
+    family: 'aws-sdk-go-v2'
+    major: '1'
+    minor: '18'
+    patch: 
 
   - user_agent_string: 'aws-sdk-nodejs/2.141.0 win32/v8.4.0'
     family: 'aws-sdk-nodejs'
     major: '2'
     minor: '141'
     patch: '0'
+    
+  - user_agent_string: 'aws-sdk-js/3.186 os/linux/5.15 lang/js md/nodejs/18.15 api/sts/3.186'
+    family: 'aws-sdk-js'
+    major: '3'
+    minor: '186'
+    patch: 
 
   - user_agent_string: 'JetS3t/0.9.0 (Linux/4.4.0-1044-aws; amd64; en; JVM 1.8.0_131)'
     family: 'JetS3t'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7943,7 +7943,7 @@ test_cases:
     family: 'aws-sdk-ruby3'
     major: '3'
     minor: '170'
-    patch: 0
+    patch: 
 
   - user_agent_string: 'aws-sdk-cpp/1.0.64 Linux/4.4.0-66-generic x86_64'
     family: 'aws-sdk-cpp'


### PR DESCRIPTION
Hello, I've being using this library successfuly in a data processing pipeline. Recently, I've noticied some useragent strings are not being processed correctly. 

For example:
aws-sdk-go-v2/1.18 os/linux lang/go/1.20 md/GOOS/linux md/GOARCH/amd64 api/sts/1.18
aws-sdk-js/3.294 os/linux/5.15 lang/js md/nodejs/16.19 api/dynamodb/3.294
aws-sdk-ruby3/3.170 ruby/3.0 x86_64-linux-musl aws-sdk-core/3.170

For such strings, ua-parser does not identifies the user_agent family or the major/minor versions.