### PR TITLE
Detect Chrome iOS when the Request Desktop Site feature is enabled

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -466,6 +466,8 @@ user_agent_parsers:
     family_replacement: 'Chrome Mobile'
   - regex: '(CriOS)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile iOS'
+  - regex: '(CriOS)/(\d+)'
+    family_replacement: 'Chrome Mobile iOS'
   - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+) Mobile(?:[ /]|$)'
     family_replacement: 'Chrome Mobile'
   - regex: ' Mobile .{1,300}(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8681,3 +8681,15 @@ test_cases:
     major: '3'
     minor: '2'
     patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1'
+    family: 'Chrome Mobile iOS'
+    major: '56'
+    minor: '0'
+    patch: '2924'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/85 Version/11.1.1 Safari/605.1.15'
+    family: 'Chrome Mobile iOS'
+    major: '85'
+    minor:
+    patch:


### PR DESCRIPTION
When the Request Desktop Site feature is enabled, Chrome on iOS only includes the major revision in the user agent. This change adds support for that and adds two test cases (examples of Chrome on iOS with and without the Request Desktop Site feature). See https://developer.chrome.com/docs/multidevice/user-agent/#chrome-for-ios