### PR TITLE
fix: Update nintendo regex to handle Nintendo Switch

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -5615,7 +5615,7 @@ device_parsers:
     device_replacement: 'Nintendo Wii U'
     brand_replacement: 'Nintendo'
     model_replacement: 'Wii U'
-  - regex: 'Nintendo (DS|3DS|DSi|Wii);'
+  - regex: 'Nintendo (Switch|DS|3DS|DSi|Wii);'
     device_replacement: 'Nintendo $1'
     brand_replacement: 'Nintendo'
     model_replacement: '$1'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -42605,6 +42605,11 @@ test_cases:
     brand: 'Nintendo'
     model: 'Wii'
 
+  - user_agent_string: 'Mozilla/5.0 (Nintendo Switch; WifiWebAuthApplet) AppleWebKit/609.4 (KHTML, like Gecko) NF/6.0.2.23.6 NintendoBrowser/5.1.0.23620'
+    family: 'Nintendo Switch'
+    brand: 'Nintendo'
+    model: 'Switch'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 5.0 kitkat; en-US; Nokia-1100 Build/GINGERBREAD) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.0.321 U3/0.8.0 Mobile Safari/534.31'
     family: 'Nokia-1100'
     brand: 'Nokia'


### PR DESCRIPTION
Before this change, the Nintendo Switch UA wasn't being fully parsed, so the OS was considered to be "Other", which is the default value. This fixes it, by updating the Nintendo regex to handle it properly.