### PR TITLE
fix: parse Edge on iPad OS properly

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -388,7 +388,7 @@ user_agent_parsers:
   # Edge Mobile
   - regex: 'Windows Phone .{0,200}(Edge)/(\d+)\.(\d+)'
     family_replacement: 'Edge Mobile'
-  - regex: '(EdgiOS|EdgA)/(\d+)\.(\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '(EdgiOS|EdgA)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
     family_replacement: 'Edge Mobile'
 
   # Oculus Browser, should go before Samsung Internet

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8699,3 +8699,9 @@ test_cases:
     major: '102'
     minor: '13'
     patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/108 Version/13.0.3 Safari/605.1.15'
+    family: 'Edge Mobile'
+    major: '108'
+    minor:
+    patch:


### PR DESCRIPTION
The UA for Edge on iPad OS doesn't specify the full edge version, but only the major. This changes the regex so that both minor & patch versions are optional.