### PR TITLE
Oculus updates for updated version number scheme and Quest 3 headset.

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -392,7 +392,7 @@ user_agent_parsers:
     family_replacement: 'Edge Mobile'
 
   # Oculus Browser, should go before Samsung Internet
-  - regex: '(OculusBrowser)/(\d+)\.(\d+).0.0(?:\.([0-9\-]+)|)'
+  - regex: '(OculusBrowser)/(\d+)\.(\d+).0(?:\.([0-9\-]+)|)'
     family_replacement: 'Oculus Browser'
 
   # Samsung Internet (based on Chrome, but lacking some features)
@@ -3582,6 +3582,11 @@ device_parsers:
   # Meta
   # @ref: https://www.meta.com
   #########
+  - regex: 'Quest 3'
+    device_replacement: 'Quest'
+    brand_replacement: 'Meta'
+    model_replacement: 'Quest 3'
+
   - regex: 'Quest 2'
     device_replacement: 'Quest'
     brand_replacement: 'Meta'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -150,12 +150,17 @@ test_cases:
     brand: 'Meta'
     model: 'Quest'
 
-  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/26.2.0.0.10 SamsungBrowser/4.0 Chrome/110.0.5481.192 VR Safari/537.36'
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/29.1.0.14.88.521409580 SamsungBrowser/4.0 Chrome/116.0.5845.172 VR Safari/537.36'
     family: 'Quest'
     brand: 'Meta'
     model: 'Quest 2'
 
-  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; Quest Pro) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/26.2.0.0.10 SamsungBrowser/4.0 Chrome/110.0.5481.192 VR Safari/537.36'
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; Quest 3) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/29.1.0.14.88.521409580 SamsungBrowser/4.0 Chrome/116.0.5845.172 VR Safari/537.36'
+    family: 'Quest'
+    brand: 'Meta'
+    model: 'Quest 3'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; Quest Pro) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/29.1.0.14.88.521409580 SamsungBrowser/4.0 Chrome/116.0.5845.172 VR Safari/537.36'
     family: 'Quest'
     brand: 'Meta'
     model: 'Quest Pro'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -83,11 +83,11 @@ test_cases:
     minor: '5'
     patch: '1'
 
-  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/26.2.0.0.10 SamsungBrowser/4.0 Chrome/110.0.5481.192 VR Safari/537.36'
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/29.1.0.14.88.521409580 SamsungBrowser/4.0 Chrome/116.0.5845.172 VR Safari/537.36'
     family: 'Oculus Browser'
-    major: '26'
-    minor: '2'
-    patch: '10'
+    major: '29'
+    minor: '1'
+    patch: '14'
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true'
     family: 'Amazon Silk'


### PR DESCRIPTION
Update OculusBrowser regex to match current versions. Update UAs in tests to match latest versions. Add support and test for Quest 3.