### PR TITLE
feat: add support to new DuckDuckGo user-agents

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -450,8 +450,14 @@ user_agent_parsers:
     family_replacement: 'QQ Browser'
 
   # DuckDuckGo
-  - regex: 'Mobile.{0,200}(DuckDuckGo)/(\d+)'
+  - regex: 'Mozilla.{1,200}Mobile.{1,100}(DuckDuckGo)/(\d+)'
     family_replacement: 'DuckDuckGo Mobile'
+  - regex: 'Mozilla.{1,200}(DuckDuckGo)/(\d+)'
+    family_replacement: 'DuckDuckGo'
+  - regex: 'Mozilla.{1,200}Mobile.{1,100}(Ddg)/(\d+)(?:\.(\d+)|)'
+    family_replacement: 'DuckDuckGo Mobile'
+  - regex: 'Mozilla.{1,200}(Ddg)/(\d+)(?:\.(\d+)|)'
+    family_replacement: 'DuckDuckGo'
 
   # Tenta Browser
   - regex: '(Tenta/)(\d+)\.(\d+)\.(\d+)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8406,6 +8406,18 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1 Ddg/17.2'
+    family: 'DuckDuckGo Mobile'
+    major: '17'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15 Ddg/17.2'
+    family: 'DuckDuckGo'
+    major: '17'
+    minor: '2'
+    patch:
+
   - user_agent_string: 'Mozilla/5.0 [en] (X11, U; OpenVAS-VT 8.0.9)'
     family: 'OpenVAS Scanner'
     major: '8'


### PR DESCRIPTION
DuckDuckGo released desktop versions of their browser and also changed the user-agent pattern to `Ddg/`. I added the new pattern while keeping the old one for backward compatibility.