### PR TITLE
fix: update Brave Browser regex

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -379,7 +379,7 @@ user_agent_parsers:
     family_replacement: 'NetFront NX'
 
   # Brave Browser https://brave.com/ , should go before Safari and Chrome Mobile
-  - regex: '((?:B|b)rave(?:\s+Chrome)?)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
+  - regex: '((?:B|b)rave(?:\sChrome)?)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
     family_replacement: 'Brave'
 
   # Amazon Silk, should go before Safari and Chrome Mobile

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -378,6 +378,10 @@ user_agent_parsers:
   - regex: '(Nintendo 3DS)'
     family_replacement: 'NetFront NX'
 
+  # Brave Browser https://brave.com/ , should go before Safari and Chrome Mobile
+  - regex: '((?:B|b)rave(?:\s+Chrome)?)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
+    family_replacement: 'Brave'
+
   # Amazon Silk, should go before Safari and Chrome Mobile
   - regex: '(Silk)/(\d+)\.(\d+)(?:\.([0-9\-]+)|)'
     family_replacement: 'Amazon Silk'
@@ -613,10 +617,6 @@ user_agent_parsers:
   # Edge with chromium Edg/major_version.minor_version.patch.minor_patch
   - regex: '(Edge?)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
     family_replacement: 'Edge'
-
-  # Brave Browser https://brave.com/
-  - regex: '(brave)/(\d+)\.(\d+)\.(\d+) Chrome'
-    family_replacement: 'Brave'
 
   # Iron Browser ~since version 50
   - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+)[\d.]{0,100} Iron[^/]'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -6974,17 +6974,47 @@ test_cases:
     minor: '7'
     patch: '11'
 
-  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.12 Chrome/47.0.2526.110 Brave/0.36.7 Safari/537.36 '
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.12 Chrome/47.0.2526.110 Brave/0.36.7 Safari/537.36'
     family: 'Brave'
     major: '0'
     minor: '7'
     patch: '12'
 
-  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.10 Chrome/47.0.2526.110 Brave/0.36.5 Safari/537.36'
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Brave Chrome/80.0.3987.87 Safari/537.36'
     family: 'Brave'
-    major: '0'
-    minor: '7'
-    patch: '10'
+    major: '80'
+    minor: '0'
+    patch: '3987'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.4577.63 Brave/117.1.4577.63 Mobile Safari/537.36'
+    family: 'Brave'
+    major: '117'
+    minor: '1'
+    patch: '4577'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36 Brave/101'
+    family: 'Brave'
+    major: '101'
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Brave/537.36'
+    family: 'Brave'
+    major: '537'
+    minor: '36'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Mobile Safari/537.36 Brave/1.40.128'
+    family: 'Brave'
+    major: '1'
+    minor: '40'
+    patch: '128'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.4472.124 Safari/537.3 brave/5035'
+    family: 'Brave'
+    major: '5035'
+    minor:
+    patch:
 
   - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome Safari/537.36'
     family: 'HeadlessChrome'


### PR DESCRIPTION
- Improved Brave regex to match other versioning structures
- Moved it up the file otherwise `Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Mobile Safari/537.36 Brave/1.40.128` would parse as `Chrome Mobile`