### PR TITLE
fix missing and extra `patch_minor` in ua tests

### DIFF
--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -190,12 +190,14 @@ test_cases:
     major: '6'
     minor: '13'
     patch: '13719'
+    patch_minor: '201'
 
   - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0; QQBrowser/7.6.21433.400)'
     family: 'QQ Browser'
     major: '7'
     minor: '6'
     patch: '21433'
+    patch_minor: '400'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; MI 2S Build/JRO03L) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.0 Mobile Safari/537.36'
     family: 'QQ Browser Mobile'
@@ -304,6 +306,7 @@ test_cases:
     major: '68'
     minor: '0'
     patch: '3440'
+    patch_minor: '85'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.1.2; Nexus 5X Build/N2G47W; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36'
     family: 'Chrome Mobile WebView'
@@ -760,6 +763,7 @@ test_cases:
     major: '7'
     minor: '4'
     patch: '1'
+    patch_minor: '14'
 
   - user_agent_string: 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13'
     family: 'Nokia Browser'
@@ -922,12 +926,14 @@ test_cases:
     major: '2'
     minor: '2'
     patch: '0'
+    patch_minor: '0'
 
   - user_agent_string: 'Mozilla/5.0 (Series40; NokiaX2-05/08.35; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/2.0.2.68.14'
     family: 'Ovi Browser'
     major: '2'
     minor: '0'
     patch: '2'
+    patch_minor: '68'
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 5.1; rv:2.0) Gecko/20110407 Firefox/4.0.3 PaleMoon/4.0.3'
     family: 'Pale Moon'
@@ -1198,24 +1204,28 @@ test_cases:
     major: '0'
     minor: '9'
     patch: '1'
+    patch_minor: '679'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Whale/0.9.5.0 Mobile Safari/537.36'
     family: 'Whale'
     major: '0'
     minor: '9'
     patch: '5'
+    patch_minor: '0'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.1.2; Nexus 6P Build/WHALE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.220 Whale/1.3.50.3 Mobile Safari/537.36 sidebar webpanel'
     family: 'Whale'
     major: '1'
     minor: '3'
     patch: '50'
+    patch_minor: '3'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.1.2; Nexus 6P Build/WHALE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.220 Whale/1.3.50.3 Mobile Safari/537.36'
     family: 'Whale'
     major: '1'
     minor: '3'
     patch: '50'
+    patch_minor: '3'
 
   - user_agent_string: 'J2ME/UCWEB7.0.3.45/139/7682'
     family: 'UC Browser'
@@ -1522,7 +1532,7 @@ test_cases:
     major: '2'
     minor: '2'
     patch: '0'
-    patch_minor:
+    patch_minor: '0'
 
   - user_agent_string: 'iRAPP/1.16.0 NokiaN95_8GB/31.0.015; Series60/3.1 Profile/MIDP-2.0 Configuration/CLDC-1.'
     family: 'iRAPP'
@@ -6798,7 +6808,7 @@ test_cases:
     major: '194'
     minor: '0'
     patch: '0'
-    patch_minor: '38'
+    patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_4 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10B350 [Pinterest/iOS]'
     family: 'Pinterest'
@@ -6997,6 +7007,7 @@ test_cases:
     major: '44'
     minor: '5'
     patch: '0'
+    patch_minor: '10'
 
   - user_agent_string: 'Mozilla/5.0 (iPad; CPU OS 12_5_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 EdgiOS/46.3.26 Mobile/15E148 Safari/605.1.15'
     family: 'Edge Mobile'
@@ -7009,6 +7020,7 @@ test_cases:
     major: '42'
     minor: '0'
     patch: '0'
+    patch_minor: '2057'
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.11 Chrome/47.0.2526.110 Brave/0.36.5 Safari/537.36'
     family: 'Brave'
@@ -7027,12 +7039,14 @@ test_cases:
     major: '80'
     minor: '0'
     patch: '3987'
+    patch_minor: '87'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.4577.63 Brave/117.1.4577.63 Mobile Safari/537.36'
     family: 'Brave'
     major: '117'
     minor: '1'
     patch: '4577'
+    patch_minor: '63'
 
   - user_agent_string: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36 Brave/101'
     family: 'Brave'
@@ -7183,12 +7197,14 @@ test_cases:
     major: '14'
     minor: '43'
     patch: '343'
+    patch_minor: '17'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1; Z831 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.94 Mobile Crosswalk/11.45.2454.20160425 Mobile Safari/537.36'
     family: 'Crosswalk'
     major: '11'
     minor: '45'
     patch: '2454'
+    patch_minor: '20160425'
 
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Mobile/15A372 Safari Line/7.12.0'
     family: 'LINE'
@@ -7955,7 +7971,6 @@ test_cases:
     major: '3'
     minor: '3'
     patch: '11'
-    patch_minor: '0'
 
   - user_agent_string: 'Boto/2.48.0 Python/2.7.14 Linux/4.2.0-41-generic'
     family: 'Boto'
@@ -8131,6 +8146,7 @@ test_cases:
     major: '4'
     minor: '2'
     patch: '2'
+    patch_minor: '38484'
 
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0_2 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/36.0.169645775 Mobile/15A421 Safari/604.1'
     family: 'Google'
@@ -8235,6 +8251,7 @@ test_cases:
     major: '10'
     minor: '29'
     patch: '1'
+    patch_minor: '0'
 
   - user_agent_string: 'OgScrper/1.0.0'
     family: 'OgScrper'
@@ -8771,12 +8788,14 @@ test_cases:
     major: '8'
     minor: '1'
     patch: '3'
+    patch_minor: '72'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Redmi 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.41 Mobile Safari/537.36 (Ecosia android@101.0.4951.41)'
     family: 'Ecosia Android'
     major: '101'
     minor: '0'
     patch: '4951'
+    patch_minor: '41'
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:102.0) Gecko/20100101 MullvadBrowser/102.13.0'
     family: 'MullvadBrowser'
@@ -8862,3 +8881,4 @@ test_cases:
     major: '1'
     minor: '3'
     patch: '0'
+    patch_minor: '0'


### PR DESCRIPTION
`patch_minor` was added to regexes and some test_ua entries in #322.

Neither spec nor reference implementation were ever updated for it, so many regexes were merged (?) with a capture for `patch_minor` but without correctly asserting it, and a pair of cases specify a `patch_minor` which is not captured:

- the facebook regex[^1] only has 4 capturing groups
- same for the AWS regex[^2]

[^1]: https://github.com/ua-parser/uap-core/blob/959e106754828ae557b0dbcfaf8eeee938d3c824/regexes.yaml#L176
[^2]: https://github.com/ua-parser/uap-core/blob/959e106754828ae557b0dbcfaf8eeee938d3c824/regexes.yaml#L155