### PR TITLE
fix: parse Chrome and Edge mobile on iOS as iOS, even with desktop mode on

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1308,6 +1308,10 @@ os_parsers:
   ##########
   - regex: '(Tizen)[/ ](\d+)\.(\d+)'
 
+  # Chrome and Edge on iOS with desktop mode contains Mac OS X, so it must be before any Mac OS check
+  - regex: 'Intel Mac OS X.+(CriOS|EdgiOS)/\d+'
+    os_replacement: 'iOS'
+
   ##########
   # Mac OS
   # @ref: http://en.wikipedia.org/wiki/Mac_OS_X#Versions

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -2762,6 +2762,20 @@ test_cases:
     patch: '3'
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/102 Version/11.1.1 Safari/605.1.15'
+    family: 'iOS'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/125 Version/13.0.3 Safari/605.1.15'
+    family: 'iOS'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU IPhone OS 9_2_1 Like Mac OS X) AppleWebKit/601.1.46 (KHTML, Like Gecko) Mobile/13D15 [FBAN/FBIOS;FBAV/52.0.0.46.157;FBBV/26424168;FBDV/iPhone6,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/9.2.1;FBSS/2; FBCR/Globe;FBID/phone;FBLC/en_US;FBOP/5]'
     family: 'iOS'
     major: '9'


### PR DESCRIPTION
The desktop mode on both those applications changes the user-agent, making it say that the device runs Mac OS X. However, this still runs on iOS, and should be parsed as is.