### PR TITLE
fix(device): ensure chromecast parsing doesn't return null

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -2513,7 +2513,7 @@ device_parsers:
   - regex: 'CrKey/'
     brand_replacement: 'Google'
     device_replacement: 'Chromecast'
-    model_replacement: null
+    model_replacement: 'Chromecast'
 
   #########
   # Cloudfone

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -7763,7 +7763,7 @@ test_cases:
   - user_agent_string: 'Mozilla/5.0 (X11; Linux armv7l) CrKey/1'
     family: 'Chromecast'
     brand: 'Google'
-    model: null
+    model: 'Chromecast'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.5; En-gb; Cloudfone_Excite320e Build/GRJ90) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1'
     family: 'Cloudfone Excite 320e'


### PR DESCRIPTION
This is supported by the JS library, but not by all the others. This sets the model to Chromecast, to prevent any possible error going on, as the model is needed in that regex.

Fixes https://github.com/ua-parser/uap-core/issues/587