### PR TITLE
fix: update ecosia browser regex to match multiple versioning structures

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -487,9 +487,9 @@ user_agent_parsers:
     family_replacement: 'Tenta Browser'
 
   # Ecosia on iOS / Android
-  - regex: '(Ecosia) ios@(\d+)\.(\d+)\.(\d+)\.(\d+)'
+  - regex: '(Ecosia) ios@(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
     family_replacement: 'Ecosia iOS'
-  - regex: '(Ecosia) android@(\d+)\.(\d+)\.(\d+)\.(\d+)'
+  - regex: '(Ecosia) android@(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
     family_replacement: 'Ecosia Android'
 
   # Chrome Mobile

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8797,6 +8797,13 @@ test_cases:
     patch: '4951'
     patch_minor: '41'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36 (Ecosia android@119)'
+    family: 'Ecosia Android'
+    major: '119'
+    minor:
+    patch:
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:102.0) Gecko/20100101 MullvadBrowser/102.13.0'
     family: 'MullvadBrowser'
     major: '102'


### PR DESCRIPTION
Ecosia for Android changed it's versioning structure. I also changed Ecosia for iOS to accept the same structure for consistency and in case it will change in the future.