### PR TITLE
chore: add lbarthon & migueldemoura to maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Maintainers
 * [Com Menthol](https://github.com/commenthol)
 * [Lindsey Simon](https://github.com/elsigh) ([@elsigh](https://twitter.com/elsigh))
 * [Tobie Langel](https://github.com/tobie) ([@tobie](https://twitter.com/tobie))
+* [Louis Barthonet](https://github.com/lbarthon)
+* [Miguel de Moura](https://github.com/migueldemoura)
 
 Communication channels
 -----------------------


### PR DESCRIPTION
As the core maintainers of this project became less active, Miguel de Moura and myself have been added as maintainers. This updates the official list to reflect a change that happened more than a year ago.