### PR TITLE
fix: ensure HarmonyOS test matches regex

### DIFF
--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -3370,7 +3370,7 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (TAS-AL00 Build/HUAWEITAS-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/97.0.4692.98 Mobile Safari/537.36 T7/13.76 BDOS/1.0 (HarmonyOS 3.0.0) SP-engine/3.17.0 baiduboxapp/13.76.0.10 (Baidu; P1 12) NABar/1.0'
-    family: 'Harmony'
+    family: 'HarmonyOS'
     major: '3'
     minor: '0'
     patch: '0'


### PR DESCRIPTION
This was part of https://github.com/ua-parser/uap-core/pull/604 - but the test was broken and got to master.