### PR TITLE
Add support for multiple browsers

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -616,6 +616,10 @@ user_agent_parsers:
   - regex: '(Atom)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Atom Browser'
 
+  # 360 Secure Browser
+  - regex: '(Chrome)/\d+\.\d+\.\d+\.\d+ .* QIHU 360(?:SEi18n|ENT)'
+    family_replacement: '360 Secure Browser'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -585,6 +585,10 @@ user_agent_parsers:
   - regex: '^(surveyon)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Surveyon'
 
+  # 115 Browser
+  - regex: '(115Browser)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: '115 Browser'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -611,6 +611,10 @@ user_agent_parsers:
   # Smart Lenovo Browser
   - regex: '(SLBrowser)/(\d+)\.(\d+)\.(\d+)\.(\d+) SLBChan/(\d+)'
     family_replacement: 'Smart Lenovo Browser'
+  
+  # Atom Browser
+  - regex: '(Atom)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Atom Browser'
 
   #### END SPECIAL CASES TOP ####
 

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -600,6 +600,14 @@ user_agent_parsers:
   # Norton
   - regex: '(Norton)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Norton'
+
+  # Quark
+  - regex: '(Quark)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Quark'
+  # Quark PC
+  - regex: '(QuarkPC)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Quark PC'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -589,6 +589,10 @@ user_agent_parsers:
   - regex: '(115Browser)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: '115 Browser'
 
+ # Avira
+  - regex: '(Avira)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Avira'
+    
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -425,7 +425,7 @@ user_agent_parsers:
     family_replacement: 'Edge Mobile'
 
   # Oculus Browser, should go before Samsung Internet
-  - regex: '(OculusBrowser)/(\d+)\.(\d+).0.0(?:\.([0-9\-]+)|)'
+  - regex: '(OculusBrowser)/(\d+)\.(\d+)(?:\.([0-9\-]+)|)'
     family_replacement: 'Oculus Browser'
 
   # Samsung Internet (based on Chrome, but lacking some features)

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -620,6 +620,10 @@ user_agent_parsers:
   - regex: '(Chrome)/\d+\.\d+\.\d+\.\d+ .* QIHU 360(?:SEi18n|ENT)'
     family_replacement: '360 Secure Browser'
 
+  # Decentr Web3 Browser
+  - regex: '(Decentr)'
+    family_replacement: 'Decentr Web3 Browser'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -592,7 +592,14 @@ user_agent_parsers:
  # Avira
   - regex: '(Avira)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Avira'
-    
+
+  # CCleaner Browser
+  - regex: '(CCleaner)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'CCleaner'
+
+  # Norton
+  - regex: '(Norton)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Norton'
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -608,6 +608,10 @@ user_agent_parsers:
   - regex: '(QuarkPC)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Quark PC'
 
+  # Smart Lenovo Browser
+  - regex: '(SLBrowser)/(\d+)\.(\d+)\.(\d+)\.(\d+) SLBChan/(\d+)'
+    family_replacement: 'Smart Lenovo Browser'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -9009,3 +9009,9 @@ test_cases:
     major:
     minor:
     patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Decentr Safari/537.36'
+    family: 'Decentr Web3 Browser'
+    major:
+    minor:
+    patch:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8949,3 +8949,9 @@ test_cases:
     major: '35'
     minor: '2'
     patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Avira/131.0.0.0'
+    family: 'Avira'
+    major: '131'
+    minor: '0'
+    patch: '0'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8991,3 +8991,9 @@ test_cases:
     major: '9'
     minor: '0'
     patch: '5'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Atom/26.0.0.0 Safari/537.36'
+    family: 'Atom Browser'
+    major: '26'
+    minor: '0'
+    patch: '0'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8955,3 +8955,15 @@ test_cases:
     major: '131'
     minor: '0'
     patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 CCleaner/131.0.0.0'
+    family: 'CCleaner'
+    major: '131'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Norton/131.0.0.0'
+    family: 'Norton'
+    major: '131'
+    minor: '0'
+    patch: '0'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8943,3 +8943,9 @@ test_cases:
     major: '1'
     minor: '0'
     patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 115Browser/35.2.0.3'
+    family: '115 Browser'
+    major: '35'
+    minor: '2'
+    patch: '0'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -87,7 +87,13 @@ test_cases:
     family: 'Oculus Browser'
     major: '26'
     minor: '2'
-    patch: '10'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64; Quest 3) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/36.6.0.9.50.692136875 Chrome/130.0.6723.191 VR Safari/537.36'
+    family: 'Oculus Browser'
+    major: '36'
+    minor: '6'
+    patch: '0'
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true'
     family: 'Amazon Silk'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8979,3 +8979,9 @@ test_cases:
     major: '2'
     minor: '0'
     patch: '7'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 SLBrowser/9.0.5.12181 SLBChan/105 SLBVPV/64-bit'
+    family: 'Smart Lenovo Browser'
+    major: '9'
+    minor: '0'
+    patch: '5'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8997,3 +8997,15 @@ test_cases:
     major: '26'
     minor: '0'
     patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.85 Safari/537.36 QIHU 360SEi18n'
+    family: '360 Secure Browser'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36 QIHU 360ENT'
+    family: '360 Secure Browser'
+    major:
+    minor:
+    patch:

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -8967,3 +8967,15 @@ test_cases:
     major: '131'
     minor: '0'
     patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 5.2;. en-US) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.6312.80 Safari/537.36 Quark/7.8.0.750'
+    family: 'Quark'
+    major: '7'
+    minor: '8'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 QuarkPC/2.0.7.222'
+    family: 'Quark PC'
+    major: '2'
+    minor: '0'
+    patch: '7'


### PR DESCRIPTION
Add support for:
* 115 Browser
* Avira Browser
* Norton Browser
* Quark & Quark PC Browser
* Smart Lenovo Browser
* Atom Browser
* 360 Secure Browser
* Decentr Web3 Browser

Fix Oculus Browser regex