### PR TITLE
Add Mastodon Bot UA

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -128,6 +128,10 @@ user_agent_parsers:
   - regex: '(Twitterbot)/(\d+)\.(\d+)'
     family_replacement: 'Twitterbot'
 
+  # Mastodon
+  - regex: '(Mastodon)\/(\d+)\.(\d+)\.(\d+(-\S*)?)'
+    family_replacement: 'Mastodon'
+
   # Bots Pattern 'name/0.0.0'
   - regex: '/((?:Ant-|)Nutch|[A-z]+[Bb]ot|[A-z]+[Ss]pider|Axtaris|fetchurl|Isara|ShopSalad|Tailsweep)[ \-](\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
   # Bots Pattern 'name/0.0.0'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -470,6 +470,18 @@ test_cases:
     minor: '0'
     patch:
 
+  - user_agent_string: 'Mastodon/4.4.3 (http.rb/5.3.1; +https://mastodon.world/) Bot'
+    family: 'Mastodon'
+    major: '4'
+    minor: '4'
+    patch: '3'
+
+  - user_agent_string: 'Mastodon/4.5.0-alpha.1 (http.rb/5.3.1; +https://aus.social/)'
+    family: 'Mastodon'
+    major: '4'
+    minor: '5'
+    patch: '0-apha.1'
+
   - user_agent_string: 'WhatsApp/2.17.70 W'
     family: 'WhatsApp'
     major: '2'


### PR DESCRIPTION
The Mastodon Bot UA is missing from the list. Amongst other things I guess, the bot is used by Mastodon servers to parse webpages for displaying links in a fashionable manner (as per the [_PreviewCard_ documentation](https://docs.joinmastodon.org/entities/PreviewCard/)).