### PR TITLE
Add new Brave iOS UA regex pattern

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -410,8 +410,12 @@ user_agent_parsers:
   - regex: '(AlohaBrowser|ABB)/(\d+)\.(\d+)\.(\d+)(?:\.(\d+)|)'
     family_replacement: 'Aloha Browser'
 
-  # Brave Browser https://brave.com/ , should go before Safari and Chrome Mobile
+  # Brave Browser, should go before Safari and Chrome Mobile
   - regex: '((?:B|b)rave(?:\sChrome)?)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
+    family_replacement: 'Brave'
+
+  # Brave iOS Browser, checks for (Brave) or Brave at end
+  - regex: '(?:\()?Brave(?:\))?\s*$'
     family_replacement: 'Brave'
 
   # Amazon Silk, should go before Safari and Chrome Mobile

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -7156,6 +7156,19 @@ test_cases:
     minor:
     patch:
 
+  # Brave iOS, checks for (Brave) or Brave at end
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1 Brave'
+    family: 'Brave'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1 (Brave)'
+    family: 'Brave'
+    major:
+    minor:
+    patch:
+
   - user_agent_string: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome Safari/537.36'
     family: 'HeadlessChrome'
     major:


### PR DESCRIPTION
We're considering changing the Brave iOS User Agent string to add `Brave` or `(Brave)` to end of the UA string. We will probably experiment with both + our existing `Brave/1` for a while, hence adding new parsing logic.