### PR TITLE
Add support for Sentry {CLI,MCP,Uptime Bot}

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -763,6 +763,18 @@ user_agent_parsers:
   # Ancestry.com Android app
   - regex: '(AncestryAndroid)/(\d+)\.(\d+)(?:\.(\d+)|)'
 
+  # Sentry CLI
+  # @ref: https://docs.sentry.io/cli/
+  - regex: '(sentry-cli)/(\d+)\.(\d+)(?:\.(\d+)|)'
+
+  # Sentry MCP Server
+  # @ref: https://mcp.sentry.dev/
+  - regex: '(sentry-mcp)/(\d+)\.(\d+)(?:\.(\d+)|)'
+
+  # Sentry Uptime Bot
+  # @ref: https://radar.cloudflare.com/bots/directory/sentry-uptime-monitoring
+  - regex: '(SentryUptimeBot)/(\d+)\.(\d+)(?:\.(\d+)|)'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -1719,6 +1719,30 @@ test_cases:
     minor: '7'
     patch: '3020'
 
+  - user_agent_string: 'sentry-cli/1.2.3 (darwin-arm64) bun/1.3.13'
+    family: 'sentry-cli'
+    major: '1'
+    minor: '2'
+    patch: '3'
+
+  - user_agent_string: 'sentry-cli/4.5.6 (linux-x64) node/22.22.0'
+    family: 'sentry-cli'
+    major: '4'
+    minor: '5'
+    patch: '6'
+
+  - user_agent_string: 'sentry-mcp/7.8.9 (https://mcp.sentry.dev)'
+    family: 'sentry-mcp'
+    major: '7'
+    minor: '8'
+    patch: '9'
+
+  - user_agent_string: 'SentryUptimeBot/2.3 (+http://docs.sentry.io/product/alerts/uptime-monitoring/)'
+    family: 'SentryUptimeBot'
+    major: '2'
+    minor: '3'
+    patch:
+
   - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Valve Steam GameOverlay/default/1769025840) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36'
     family: 'Steam GameOverlay'
     major: '126'


### PR DESCRIPTION

`uap-core` is great! It's used in `getsentry/relay` and eventually powers UA detection throughout the product:

<img width="408" height="1310" alt="CleanShot 2026-05-15 at 12 09 35@2x" src="https://github.com/user-attachments/assets/3b681206-1a8d-4f2f-867c-371d3c599f6e" />

Would it be possible to add the UAs for various Sentry tools upstream?

---

Example user agents:
- sentry-cli/0.34.0-dev.1778667204 (linux-x64) bun/1.3.13
- sentry-cli/0.28.1 (darwin-arm64) node/24.14.0
- sentry-cli/2.53.0 vite-plugin/2.22.6
- sentry-cli/2.58.5 webpack-plugin/4.9.1
- sentry-mcp/0.23.0 (https://mcp.sentry.dev)
- sentry-mcp/0.30.0 (https://mcp.sentry.dev)
- SentryUptimeBot/1.0 (+http://docs.sentry.io/product/alerts/uptime-monitoring/)

See:
- https://docs.sentry.io/cli/
- https://mcp.sentry.dev/
- https://docs.sentry.io/product/alerts/uptime-monitoring/
- https://radar.cloudflare.com/bots/directory/sentry-uptime-monitoring
