### PR TITLE
Clean up errant whitespace in regexes.yaml

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -467,7 +467,7 @@ user_agent_parsers:
   - regex: '(SznProhlizec)/(\d+)\.(\d+)(?:\.(\d+)|)'
     family_replacement: 'Seznam prohlížeč'
 
-  # Coc Coc browser, based on Chrome (used in Vietnam)
+  # Coc Coc browser, based on Chrome (used in Vietnam)
   - regex: '(coc_coc_browser)/(\d+)\.(\d+)(?:\.(\d+)|)'
     family_replacement: 'Coc Coc'
 
@@ -734,7 +734,7 @@ user_agent_parsers:
   # Odin Browser
   - regex: '(Odin)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Odin'
-  
+
   # NetCast Smart TV
   - regex: '(Colt)/(\d+)\.(\d+)'
     family_replacement: 'NetCast Smart TV'


### PR DESCRIPTION
Replaces a non-breaking space (U+00A0) in the Coc Coc browser comment
with a regular space, and strips trailing whitespace from a blank line after
the Odin Browser entry.
