### PR TITLE
Add Microsoft Teams embedded browser detection

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -834,6 +834,10 @@ user_agent_parsers:
   # Vivaldi
   - regex: '(Vivaldi)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
 
+  # Microsoft Teams embedded browser (needs to be before Edge and Chrome)
+  - regex: '.{0,200}(Teams)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Microsoft Teams'
+
   # Edge/major_version.minor_version
   # Edge with chromium Edg/major_version.minor_version.patch.minor_patch
   - regex: '(Edge?)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -9724,3 +9724,9 @@ test_cases:
     major: '1'
     minor: '0'
     patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.0.0 Teams/26106.2110.4675.2592 (50)'
+    family: 'Microsoft Teams'
+    major: '26106'
+    minor: '2110'
+    patch: '4675'


### PR DESCRIPTION
## Summary

Adds a regex to detect the Microsoft Teams embedded browser (desktop app).

## Example User-Agent

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.0.0 Teams/26106.2110.4675.2592 (50)
```

## Changes

- **regexes.yaml**: Added `Teams` regex before the Edge/Chrome matchers (since the UA also contains `Edg/` and `Chrome/` tokens). Uses `.{0,200}` prefix to avoid catastrophic backtracking, consistent with other regexes in the file.
- **tests/test_ua.yaml**: Added a test case for the above UA string.

## Parsed result

| Field | Value |
|-------|-------|
| family | Microsoft Teams |
| major | 26106 |
| minor | 2110 |
| patch | 4675 |