### PR TITLE
Rename Samsung Internet as Samsung Browser

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -455,13 +455,13 @@ user_agent_parsers:
   - regex: '(EdgiOS|EdgA)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
     family_replacement: 'Edge Mobile'
 
-  # Oculus Browser, should go before Samsung Internet
+  # Oculus Browser, should go before Samsung Browser
   - regex: '(OculusBrowser)/(\d+)\.(\d+)(?:\.([0-9\-]+)|)'
     family_replacement: 'Oculus Browser'
 
-  # Samsung Internet (based on Chrome, but lacking some features)
+  # Samsung Browser (based on Chrome, but lacking some features)
   - regex: '(SamsungBrowser)/(\d+)\.(\d+)'
-    family_replacement: 'Samsung Internet'
+    family_replacement: 'Samsung Browser'
 
   # Seznam.cz browser (based on WebKit)
   - regex: '(SznProhlizec)/(\d+)\.(\d+)(?:\.(\d+)|)'

--- a/tests/test_ua.yaml
+++ b/tests/test_ua.yaml
@@ -4588,25 +4588,25 @@ test_cases:
     patch: '3'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG GT-I9506-ORANGE Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
-    family: 'Samsung Internet'
+    family: 'Samsung Browser'
     major: '2'
     minor: '1'
     patch:
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-T800 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.0 Chrome/38.0.2125.102 Safari/537.36'
-    family: 'Samsung Internet'
+    family: 'Samsung Browser'
     major: '3'
     minor: '0'
     patch:
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G920F Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.2 Chrome/38.0.2125.102 Mobile Safari/537.36'
-    family: 'Samsung Internet'
+    family: 'Samsung Browser'
     major: '3'
     minor: '2'
     patch:
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-T710 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Safari/537.36'
-    family: 'Samsung Internet'
+    family: 'Samsung Browser'
     major: '3'
     minor: '5'
     patch:


### PR DESCRIPTION
## Summary

Rename regex family replacement of Samsung Internet as new rebranded name `Samsung Browser`

## Example User-Agent

```
Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/28.0 Chrome/130.0.0.0 Mobile Safari/537.36
```

## Changes

- **regexes.yaml**: Rename regex family replacement of Samsung Internet as Samsung Browser
- **tests/test_ua.yaml**: Modify test cases for the above UA string.

## Parsed result

| Field | Value |
|-------|-------|
| family | Samsung Browser|