### PR TITLE
add support for native macOS user-agents in Darwin 25+

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1788,6 +1788,31 @@ os_parsers:
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '11'
+  # explicit "macOS" token; matched before the iOS ladder as the Darwin major is
+  # shared. version comes from Darwin, not the CFNetwork build after "macOS/"
+  - regex: 'CFNetwork/.{0,100}macOS/.{0,100} Darwin/26\.([0-5])\.\d+'
+    os_replacement: 'macOS'
+    os_v1_replacement: '27'
+    os_v2_replacement: '$1'
+  - regex: 'CFNetwork/.{0,100}macOS/.{0,100} Darwin/(26)\.\d+'
+    os_replacement: 'macOS'
+    os_v1_replacement: '27'
+  - regex: 'CFNetwork/.{0,100}macOS/.{0,100} Darwin/25\.([0-5])\.\d+'
+    os_replacement: 'macOS'
+    os_v1_replacement: '26'
+    os_v2_replacement: '$1'
+  - regex: 'CFNetwork/.{0,100}macOS/.{0,100} Darwin/(25)\.\d+'
+    os_replacement: 'macOS'
+    os_v1_replacement: '26'
+  - regex: 'CFNetwork/.{0,100}macOS/.{0,100} Darwin/24\.([0-5])\.\d+'
+    os_replacement: 'macOS'
+    os_v1_replacement: '15'
+    os_v2_replacement: '$1'
+  - regex: 'CFNetwork/.{0,100}macOS/.{0,100} Darwin/(24)\.\d+'
+    os_replacement: 'macOS'
+    os_v1_replacement: '15'
+  - regex: 'CFNetwork/.{0,100}macOS/.{0,100} Darwin/'
+    os_replacement: 'macOS'
   ##########
   # CFNetwork iOS Apps
   # @ref: https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
@@ -1991,6 +2016,20 @@ os_parsers:
   - regex: 'CFNetwork/.{0,100} Darwin/(24)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '18'
+  - regex: 'CFNetwork/.{0,100} Darwin/25\.([0-5])\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '26'
+    os_v2_replacement: '$1'
+  - regex: 'CFNetwork/.{0,100} Darwin/(25)\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '26'
+  - regex: 'CFNetwork/.{0,100} Darwin/26\.([0-5])\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '27'
+    os_v2_replacement: '$1'
+  - regex: 'CFNetwork/.{0,100} Darwin/(26)\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '27'
   - regex: 'CFNetwork/.{0,100} Darwin/'
     os_replacement: 'iOS'
 
@@ -5755,6 +5794,12 @@ device_parsers:
   # @note: newer desktop applications don't show device info
   # This is here so as to not have them recorded as iOS-Device
   - regex: 'CFNetwork/.{0,100} Darwin/\d+\.\d+\.\d+ \(x86_64\)'
+    device_replacement: 'Mac'
+    brand_replacement: 'Apple'
+    model_replacement: 'Mac'
+  # @note: apps with an explicit "macOS" token are Macs; arm64 Macs lack the
+  # "(x86_64)" marker above and would otherwise be recorded as iOS-Device
+  - regex: 'CFNetwork/.{0,100}macOS/.{0,100} Darwin/\d'
     device_replacement: 'Mac'
     brand_replacement: 'Apple'
     model_replacement: 'Mac'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -80633,3 +80633,9 @@ test_cases:
     family: 'Spider'
     brand: 'Spider'
     model: 'Desktop'
+
+  # CFNetwork apps with an explicit "macOS" token are Macs, not iOS-Device
+  - user_agent_string: 'Self Service+/7570 CFNetwork/macOS/3860.600.21 Darwin/25.5.0'
+    family: 'Mac'
+    brand: 'Apple'
+    model: 'Mac'

--- a/tests/test_os.yaml
+++ b/tests/test_os.yaml
@@ -3389,3 +3389,48 @@ test_cases:
     minor: '0'
     patch: '0'
     patch_minor:
+
+  # CFNetwork apps with an explicit "macOS" token; version from Darwin
+  - user_agent_string: 'Self Service+/7570 CFNetwork/macOS/3860.600.21 Darwin/25.5.0'
+    family: 'macOS'
+    major: '26'
+    minor: '5'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Cal/1.0 CFNetwork/macOS/3860.100.1 Darwin/24.4.0'
+    family: 'macOS'
+    major: '15'
+    minor: '4'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Self Service+/8100 CFNetwork/macOS/3900.100.1 Darwin/26.1.0'
+    family: 'macOS'
+    major: '27'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  # CFNetwork iOS apps on Darwin 25 (iOS 26)
+  - user_agent_string: 'App/1.0 CFNetwork/1568.100.1 Darwin/25.0.0'
+    family: 'iOS'
+    major: '26'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0 CFNetwork/1568.200.51 Darwin/25.5.0'
+    family: 'iOS'
+    major: '26'
+    minor: '5'
+    patch:
+    patch_minor:
+
+  # CFNetwork iOS apps on Darwin 26 (iOS 27)
+  - user_agent_string: 'App/1.0 CFNetwork/1600.100.1 Darwin/26.0.0'
+    family: 'iOS'
+    major: '27'
+    minor: '0'
+    patch:
+    patch_minor:


### PR DESCRIPTION
The intent of this PR is to correct a couple of misparsings from macOS applications like JAMF's Self Service+ uses.  Currently the sample `Self Service+/7570 CFNetwork/macOS/3860.600.21 Darwin/25.5.0` value is mapped to an iOS device.