### PR TITLE
Fix OnePlus device detection for UAs with an empty build token

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -4303,11 +4303,11 @@ device_parsers:
   # OnePlus
   # @ref https://oneplus.net/
   #########
-  - regex: '; (ONE [a-zA-Z]\d+)(?: Build|\) AppleWebKit)'
+  - regex: '; (ONE [a-zA-Z]\d+)(?: Build|;? {0,2}\) AppleWebKit)'
     device_replacement: 'OnePlus $1'
     brand_replacement: 'OnePlus'
     model_replacement: '$1'
-  - regex: '; (ONEPLUS [a-zA-Z]\d+)(?: Build|\) AppleWebKit)'
+  - regex: '; (ONEPLUS [a-zA-Z]\d+)(?: Build|;? {0,2}\) AppleWebKit)'
     device_replacement: 'OnePlus $1'
     brand_replacement: 'OnePlus'
     model_replacement: '$1'

--- a/tests/test_device.yaml
+++ b/tests/test_device.yaml
@@ -80270,6 +80270,16 @@ test_cases:
     brand: 'OnePlus'
     model: 'ONEPLUS A5010'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 10; ONEPLUS A7010; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.185 Mobile Safari/537.36'
+    family: 'OnePlus ONEPLUS A7010'
+    brand: 'OnePlus'
+    model: 'ONEPLUS A7010'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1; ONE E1003; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.185 Mobile Safari/537.36'
+    family: 'OnePlus ONE E1003'
+    brand: 'OnePlus'
+    model: 'ONE E1003'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPM1.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36'
     family: 'Pixel'
     brand: 'Google'


### PR DESCRIPTION
Fixes #667.

Android UAs with an empty OS build token leave a trailing `; )` in the platform section, e.g.

```
Mozilla/5.0 (Linux; Android 10; ONEPLUS A7010; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.185 Mobile Safari/537.36
```

Since 986ebc4 the OnePlus device regexes require ` Build` or `) AppleWebKit` immediately after the model, so these UAs fall through to Generic Smartphone. This change allows an optional `; ` between the model and the closing parenthesis (bounded quantifiers, `safe-regex` check passes) for both the `ONEPLUS` and `ONE` (OnePlus One family) rules, and adds test cases for the trailing-`; )` form to `tests/test_device.yaml`.

Verified: the new test cases fail without the regex change and pass with it; the full suite (`npm test`, 34,111 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
